### PR TITLE
plugin registry, completely reworked platform channels, test plugin

### DIFF
--- a/src/jsmn.h
+++ b/src/jsmn.h
@@ -1,0 +1,471 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2010 Serge Zaitsev
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+#ifndef JSMN_H
+#define JSMN_H
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef JSMN_STATIC
+#define JSMN_API static
+#else
+#define JSMN_API extern
+#endif
+
+/**
+ * JSON type identifier. Basic types are:
+ * 	o Object
+ * 	o Array
+ * 	o String
+ * 	o Other primitive: number, boolean (true/false) or null
+ */
+typedef enum {
+  JSMN_UNDEFINED = 0,
+  JSMN_OBJECT = 1,
+  JSMN_ARRAY = 2,
+  JSMN_STRING = 3,
+  JSMN_PRIMITIVE = 4
+} jsmntype_t;
+
+enum jsmnerr {
+  /* Not enough tokens were provided */
+  JSMN_ERROR_NOMEM = -1,
+  /* Invalid character inside JSON string */
+  JSMN_ERROR_INVAL = -2,
+  /* The string is not a full JSON packet, more bytes expected */
+  JSMN_ERROR_PART = -3
+};
+
+/**
+ * JSON token description.
+ * type		type (object, array, string etc.)
+ * start	start position in JSON data string
+ * end		end position in JSON data string
+ */
+typedef struct {
+  jsmntype_t type;
+  int start;
+  int end;
+  int size;
+#ifdef JSMN_PARENT_LINKS
+  int parent;
+#endif
+} jsmntok_t;
+
+/**
+ * JSON parser. Contains an array of token blocks available. Also stores
+ * the string being parsed now and current position in that string.
+ */
+typedef struct {
+  unsigned int pos;     /* offset in the JSON string */
+  unsigned int toknext; /* next token to allocate */
+  int toksuper;         /* superior token node, e.g. parent object or array */
+} jsmn_parser;
+
+/**
+ * Create JSON parser over an array of tokens
+ */
+JSMN_API void jsmn_init(jsmn_parser *parser);
+
+/**
+ * Run JSON parser. It parses a JSON data string into and array of tokens, each
+ * describing
+ * a single JSON object.
+ */
+JSMN_API int jsmn_parse(jsmn_parser *parser, const char *js, const size_t len,
+                        jsmntok_t *tokens, const unsigned int num_tokens);
+
+#ifndef JSMN_HEADER
+/**
+ * Allocates a fresh unused token from the token pool.
+ */
+static jsmntok_t *jsmn_alloc_token(jsmn_parser *parser, jsmntok_t *tokens,
+                                   const size_t num_tokens) {
+  jsmntok_t *tok;
+  if (parser->toknext >= num_tokens) {
+    return NULL;
+  }
+  tok = &tokens[parser->toknext++];
+  tok->start = tok->end = -1;
+  tok->size = 0;
+#ifdef JSMN_PARENT_LINKS
+  tok->parent = -1;
+#endif
+  return tok;
+}
+
+/**
+ * Fills token type and boundaries.
+ */
+static void jsmn_fill_token(jsmntok_t *token, const jsmntype_t type,
+                            const int start, const int end) {
+  token->type = type;
+  token->start = start;
+  token->end = end;
+  token->size = 0;
+}
+
+/**
+ * Fills next available token with JSON primitive.
+ */
+static int jsmn_parse_primitive(jsmn_parser *parser, const char *js,
+                                const size_t len, jsmntok_t *tokens,
+                                const size_t num_tokens) {
+  jsmntok_t *token;
+  int start;
+
+  start = parser->pos;
+
+  for (; parser->pos < len && js[parser->pos] != '\0'; parser->pos++) {
+    switch (js[parser->pos]) {
+#ifndef JSMN_STRICT
+    /* In strict mode primitive must be followed by "," or "}" or "]" */
+    case ':':
+#endif
+    case '\t':
+    case '\r':
+    case '\n':
+    case ' ':
+    case ',':
+    case ']':
+    case '}':
+      goto found;
+    default:
+                   /* to quiet a warning from gcc*/
+      break;
+    }
+    if (js[parser->pos] < 32 || js[parser->pos] >= 127) {
+      parser->pos = start;
+      return JSMN_ERROR_INVAL;
+    }
+  }
+#ifdef JSMN_STRICT
+  /* In strict mode primitive must be followed by a comma/object/array */
+  parser->pos = start;
+  return JSMN_ERROR_PART;
+#endif
+
+found:
+  if (tokens == NULL) {
+    parser->pos--;
+    return 0;
+  }
+  token = jsmn_alloc_token(parser, tokens, num_tokens);
+  if (token == NULL) {
+    parser->pos = start;
+    return JSMN_ERROR_NOMEM;
+  }
+  jsmn_fill_token(token, JSMN_PRIMITIVE, start, parser->pos);
+#ifdef JSMN_PARENT_LINKS
+  token->parent = parser->toksuper;
+#endif
+  parser->pos--;
+  return 0;
+}
+
+/**
+ * Fills next token with JSON string.
+ */
+static int jsmn_parse_string(jsmn_parser *parser, const char *js,
+                             const size_t len, jsmntok_t *tokens,
+                             const size_t num_tokens) {
+  jsmntok_t *token;
+
+  int start = parser->pos;
+
+  parser->pos++;
+
+  /* Skip starting quote */
+  for (; parser->pos < len && js[parser->pos] != '\0'; parser->pos++) {
+    char c = js[parser->pos];
+
+    /* Quote: end of string */
+    if (c == '\"') {
+      if (tokens == NULL) {
+        return 0;
+      }
+      token = jsmn_alloc_token(parser, tokens, num_tokens);
+      if (token == NULL) {
+        parser->pos = start;
+        return JSMN_ERROR_NOMEM;
+      }
+      jsmn_fill_token(token, JSMN_STRING, start + 1, parser->pos);
+#ifdef JSMN_PARENT_LINKS
+      token->parent = parser->toksuper;
+#endif
+      return 0;
+    }
+
+    /* Backslash: Quoted symbol expected */
+    if (c == '\\' && parser->pos + 1 < len) {
+      int i;
+      parser->pos++;
+      switch (js[parser->pos]) {
+      /* Allowed escaped symbols */
+      case '\"':
+      case '/':
+      case '\\':
+      case 'b':
+      case 'f':
+      case 'r':
+      case 'n':
+      case 't':
+        break;
+      /* Allows escaped symbol \uXXXX */
+      case 'u':
+        parser->pos++;
+        for (i = 0; i < 4 && parser->pos < len && js[parser->pos] != '\0';
+             i++) {
+          /* If it isn't a hex character we have an error */
+          if (!((js[parser->pos] >= 48 && js[parser->pos] <= 57) ||   /* 0-9 */
+                (js[parser->pos] >= 65 && js[parser->pos] <= 70) ||   /* A-F */
+                (js[parser->pos] >= 97 && js[parser->pos] <= 102))) { /* a-f */
+            parser->pos = start;
+            return JSMN_ERROR_INVAL;
+          }
+          parser->pos++;
+        }
+        parser->pos--;
+        break;
+      /* Unexpected symbol */
+      default:
+        parser->pos = start;
+        return JSMN_ERROR_INVAL;
+      }
+    }
+  }
+  parser->pos = start;
+  return JSMN_ERROR_PART;
+}
+
+/**
+ * Parse JSON string and fill tokens.
+ */
+JSMN_API int jsmn_parse(jsmn_parser *parser, const char *js, const size_t len,
+                        jsmntok_t *tokens, const unsigned int num_tokens) {
+  int r;
+  int i;
+  jsmntok_t *token;
+  int count = parser->toknext;
+
+  for (; parser->pos < len && js[parser->pos] != '\0'; parser->pos++) {
+    char c;
+    jsmntype_t type;
+
+    c = js[parser->pos];
+    switch (c) {
+    case '{':
+    case '[':
+      count++;
+      if (tokens == NULL) {
+        break;
+      }
+      token = jsmn_alloc_token(parser, tokens, num_tokens);
+      if (token == NULL) {
+        return JSMN_ERROR_NOMEM;
+      }
+      if (parser->toksuper != -1) {
+        jsmntok_t *t = &tokens[parser->toksuper];
+#ifdef JSMN_STRICT
+        /* In strict mode an object or array can't become a key */
+        if (t->type == JSMN_OBJECT) {
+          return JSMN_ERROR_INVAL;
+        }
+#endif
+        t->size++;
+#ifdef JSMN_PARENT_LINKS
+        token->parent = parser->toksuper;
+#endif
+      }
+      token->type = (c == '{' ? JSMN_OBJECT : JSMN_ARRAY);
+      token->start = parser->pos;
+      parser->toksuper = parser->toknext - 1;
+      break;
+    case '}':
+    case ']':
+      if (tokens == NULL) {
+        break;
+      }
+      type = (c == '}' ? JSMN_OBJECT : JSMN_ARRAY);
+#ifdef JSMN_PARENT_LINKS
+      if (parser->toknext < 1) {
+        return JSMN_ERROR_INVAL;
+      }
+      token = &tokens[parser->toknext - 1];
+      for (;;) {
+        if (token->start != -1 && token->end == -1) {
+          if (token->type != type) {
+            return JSMN_ERROR_INVAL;
+          }
+          token->end = parser->pos + 1;
+          parser->toksuper = token->parent;
+          break;
+        }
+        if (token->parent == -1) {
+          if (token->type != type || parser->toksuper == -1) {
+            return JSMN_ERROR_INVAL;
+          }
+          break;
+        }
+        token = &tokens[token->parent];
+      }
+#else
+      for (i = parser->toknext - 1; i >= 0; i--) {
+        token = &tokens[i];
+        if (token->start != -1 && token->end == -1) {
+          if (token->type != type) {
+            return JSMN_ERROR_INVAL;
+          }
+          parser->toksuper = -1;
+          token->end = parser->pos + 1;
+          break;
+        }
+      }
+      /* Error if unmatched closing bracket */
+      if (i == -1) {
+        return JSMN_ERROR_INVAL;
+      }
+      for (; i >= 0; i--) {
+        token = &tokens[i];
+        if (token->start != -1 && token->end == -1) {
+          parser->toksuper = i;
+          break;
+        }
+      }
+#endif
+      break;
+    case '\"':
+      r = jsmn_parse_string(parser, js, len, tokens, num_tokens);
+      if (r < 0) {
+        return r;
+      }
+      count++;
+      if (parser->toksuper != -1 && tokens != NULL) {
+        tokens[parser->toksuper].size++;
+      }
+      break;
+    case '\t':
+    case '\r':
+    case '\n':
+    case ' ':
+      break;
+    case ':':
+      parser->toksuper = parser->toknext - 1;
+      break;
+    case ',':
+      if (tokens != NULL && parser->toksuper != -1 &&
+          tokens[parser->toksuper].type != JSMN_ARRAY &&
+          tokens[parser->toksuper].type != JSMN_OBJECT) {
+#ifdef JSMN_PARENT_LINKS
+        parser->toksuper = tokens[parser->toksuper].parent;
+#else
+        for (i = parser->toknext - 1; i >= 0; i--) {
+          if (tokens[i].type == JSMN_ARRAY || tokens[i].type == JSMN_OBJECT) {
+            if (tokens[i].start != -1 && tokens[i].end == -1) {
+              parser->toksuper = i;
+              break;
+            }
+          }
+        }
+#endif
+      }
+      break;
+#ifdef JSMN_STRICT
+    /* In strict mode primitives are: numbers and booleans */
+    case '-':
+    case '0':
+    case '1':
+    case '2':
+    case '3':
+    case '4':
+    case '5':
+    case '6':
+    case '7':
+    case '8':
+    case '9':
+    case 't':
+    case 'f':
+    case 'n':
+      /* And they must not be keys of the object */
+      if (tokens != NULL && parser->toksuper != -1) {
+        const jsmntok_t *t = &tokens[parser->toksuper];
+        if (t->type == JSMN_OBJECT ||
+            (t->type == JSMN_STRING && t->size != 0)) {
+          return JSMN_ERROR_INVAL;
+        }
+      }
+#else
+    /* In non-strict mode every unquoted value is a primitive */
+    default:
+#endif
+      r = jsmn_parse_primitive(parser, js, len, tokens, num_tokens);
+      if (r < 0) {
+        return r;
+      }
+      count++;
+      if (parser->toksuper != -1 && tokens != NULL) {
+        tokens[parser->toksuper].size++;
+      }
+      break;
+
+#ifdef JSMN_STRICT
+    /* Unexpected char in strict mode */
+    default:
+      return JSMN_ERROR_INVAL;
+#endif
+    }
+  }
+
+  if (tokens != NULL) {
+    for (i = parser->toknext - 1; i >= 0; i--) {
+      /* Unmatched opened object or array */
+      if (tokens[i].start != -1 && tokens[i].end == -1) {
+        return JSMN_ERROR_PART;
+      }
+    }
+  }
+
+  return count;
+}
+
+/**
+ * Creates a new parser based over a given buffer with an array of tokens
+ * available.
+ */
+JSMN_API void jsmn_init(jsmn_parser *parser) {
+  parser->pos = 0;
+  parser->toknext = 0;
+  parser->toksuper = -1;
+}
+
+#endif /* JSMN_HEADER */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* JSMN_H */

--- a/src/methodchannel.h
+++ b/src/methodchannel.h
@@ -8,27 +8,25 @@ typedef enum {
     kNull = 0,
     kTrue,
     kFalse,
-    kTypeInt,
-    kTypeLong,
-    kTypeBigInt,
-    kTypeDouble,
-    kTypeString,
-    kTypeByteArray,
-    kTypeIntArray,
-    kTypeLongArray,
-    kTypeDoubleArray,
-    kTypeList,
-    kTypeMap,
-    kNoValue = 0xFFFF
+    kInt32,
+    kInt64,
+    kLargeInt, // treat as kString
+    kFloat64,
+    kString,
+    kUInt8Array,
+    kInt32Array,
+    kInt64Array,
+    kFloat64Array,
+    kList,
+    kMap
 } MessageValueDiscriminator;
 
-struct MethodChannelValue {
+struct MessageChannelValue {
     MessageValueDiscriminator type;
     union {
         bool bool_value;
         int32_t int_value;
         int64_t long_value;
-        char* bigint_value;
         double double_value;
         char* string_value;
         struct {
@@ -49,11 +47,11 @@ struct MethodChannelValue {
         } doublearray_value;
         struct {
             size_t size;
-            struct MethodChannelValue* list;
+            struct MessageChannelValue* list;
         } list_value;
         struct {
             size_t size;
-            struct MethodChannelValue* map;
+            struct MessageChannelValue* map;
         } map_value;
     };
 };
@@ -64,11 +62,11 @@ struct MethodCall {
         kJSONProtocol
     } protocol;
     char* method;
-    struct MethodChannelValue argument;
+    struct MessageChannelValue argument;
 };
 
-bool MethodChannel_call(char* channel, char* method, struct MethodChannelValue* argument);
-bool MethodChannel_respond(FlutterPlatformMessageResponseHandle* response_handle, struct MethodChannelValue* response_value);
+bool MethodChannel_call(char* channel, char* method, struct MessageChannelValue* argument);
+bool MethodChannel_respond(FlutterPlatformMessageResponseHandle* response_handle, struct MessageChannelValue* response_value);
 bool MethodChannel_decode(size_t buffer_size, uint8_t* buffer, struct MethodCall** presult);
 bool MethodChannel_freeMethodCall(struct MethodCall** pmethodcall);
 

--- a/src/platformchannel.h
+++ b/src/platformchannel.h
@@ -86,6 +86,7 @@ struct StdMsgCodecValue {
 /// These tell this API how it should encode ChannelObjects -> platform messages
 /// and how to decode platform messages -> ChannelObjects.
 enum ChannelCodec {
+    kNotImplemented,
     kStringCodec,
     kBinaryCodec,
     kJSONMessageCodec,
@@ -98,6 +99,9 @@ enum ChannelCodec {
 
 /// Abstract Channel Object.
 /// Different properties are "valid" for different codecs:
+///   kNotImplemented:
+///     no values associated with this "codec".
+///     this represents a platform message with no buffer and zero length. (so just an empty response)
 ///   kStringCodec:
 ///     - string_value is the raw byte data of a platform message, but with an additional null-byte at the end.
 ///   kBinaryCodec:
@@ -228,7 +232,25 @@ int PlatformChannel_respondError(FlutterPlatformMessageResponseHandle *handle, e
 /// not freeing ChannelObjects may result in a memory leak.
 int PlatformChannel_free(struct ChannelObject *object);
 
-int json_findKey(struct JSONMsgCodecValue *object, char *key);
-struct JSONMsgCodecValue *json_get(struct JSONMsgCodecValue *object, char *key);
+/// returns true if values a and b are equal.
+/// for JS arrays, the order of the values is relevant
+/// (so two arrays are only equal if the same values in appear in exactly same order)
+/// for objects, the order of the entries is irrelevant.
+bool jsvalue_equals(struct JSONMsgCodecValue *a, struct JSONMsgCodecValue *b);
+
+/// given a JS object as an argument, it searches for an entry with key "key"
+/// and returns the value associated with it.
+/// if the key is not found, returns NULL.
+struct JSONMsgCodecValue *jsobject_get(struct JSONMsgCodecValue *object, char *key);
+
+/// StdMsgCodecValue equivalent of jsvalue_equals.
+/// again, for lists, the order of values is relevant
+/// for maps, it's not.
+bool stdvalue_equals(struct StdMsgCodecValue *a, struct StdMsgCodecValue *b);
+
+/// StdMsgCodecValue equivalent of jsobject_get, just that the key can be
+/// any arbitrary StdMsgCodecValue (and must not be a string as for jsobject_get)
+struct StdMsgCodecValue *stdmap_get(struct StdMsgCodecValue *map, struct StdMsgCodecValue *key);
+
 
 #endif

--- a/src/platformchannel.h
+++ b/src/platformchannel.h
@@ -4,7 +4,44 @@
 #include <stdint.h>
 #include <flutter_embedder.h>
 
-typedef enum {
+#define JSON_DECODE_TOKENLIST_SIZE  128
+
+/*
+ * It may be simpler for plugins if the two message value types were unified.
+ * But from a performance POV, this doesn't make sense. number arrays in StandardMessageCodec
+ * are 4 or 8 -byte aligned for faster access. We don't have to copy them, StdMsgCodecValue.int64array (as an example)
+ * is just a pointer to that portion of the buffer, where the array is located.
+ * 
+ * However, JSON and thus JSON Message Handlers have no idea what a int64array is, they just know of JSON arrays.
+ * This means we'd have to implicitly convert the int64array into a JSON array when we want to unify the two message value types,
+ * and this costs all the performance we (more precisely, the flutter engineers) gained by memory-aligning the arrays in StdMsgCodecValue.
+ * 
+ * Let's just hope the flutter team doesn't randomly switch codecs of platform channels. Receive Handlers would
+ * need to be rewritten every time they do. The handlers not needing to be rewritten would probably be the only advantage
+ * of using a unified message value type.
+ */
+enum JSONMsgCodecValueType {
+    kJSNull, kJSTrue, kJSFalse, kJSNumber, kJSString, kJSArray, kJSObject
+};
+struct JSONMsgCodecValue {
+    enum JSONMsgCodecValueType type;
+    union {
+        double number_value;
+        char  *string_value;
+        struct {
+            size_t size;
+            union {
+                struct JSONMsgCodecValue *array;
+                struct {
+                    char                    **keys;
+                    struct JSONMsgCodecValue *values;
+                };
+            };
+        };
+    };
+};
+
+enum StdMsgCodecValueType {
     kNull = 0,
     kTrue,
     kFalse,
@@ -19,61 +56,179 @@ typedef enum {
     kFloat64Array,
     kList,
     kMap
-} MessageValueDiscriminator;
-
-struct MessageChannelValue {
-    MessageValueDiscriminator type;
+};
+struct StdMsgCodecValue {
+    enum StdMsgCodecValueType type;
     union {
-        bool bool_value;
+        bool    bool_value;
         int32_t int32_value;
         int64_t int64_value;
-        double float64_value;
-        char* string_value;
+        double  float64_value;
+        char*   string_value;
         struct {
             size_t size;
-            uint8_t* array;
-        } uint8array_value;
-        struct {
-            size_t size;
-            int32_t* array;
-        } int32array_value;
-        struct {
-            size_t size;
-            int64_t* array;
-        } int64array_value;
-        struct {
-            size_t size;
-            double* array;
-        } float64array_value;
-        struct {
-            size_t size;
-            struct MessageChannelValue* list;
-        } list_value;
-        struct {
-            size_t size;
-            struct MessageChannelValue* map;
-        } map_value;
+            union {
+                uint8_t* uint8array;
+                int32_t* int32array;
+                int64_t* int64array;
+                double*  float64array;
+                struct StdMsgCodecValue* list;
+                struct {
+                    struct StdMsgCodecValue* keys;
+                    struct StdMsgCodecValue* values;
+                };
+            };
+        };
     };
 };
 
-struct MethodCall {
-    enum {
-        kStandardProtocol,
-        kJSONProtocol
-    } protocol;
-    char* method;
-    struct MessageChannelValue argument;
+/// codec of an abstract channel object
+/// These tell this API how it should encode ChannelObjects -> platform messages
+/// and how to decode platform messages -> ChannelObjects.
+enum ChannelCodec {
+    kStringCodec,
+    kBinaryCodec,
+    kJSONMessageCodec,
+    kStandardMessageCodec,
+    kStandardMethodCall,
+    kStandardMethodCallResponse,
+    kJSONMethodCall,
+    kJSONMethodCallResponse
 };
 
-bool PlatformChannel_calculateValueSizeInBuffer(struct MethodChannelValue* value, size_t* psize);
-bool PlatformChannel_writeValueToBuffer(struct MessageChannelValue *value, uint8_t **pbuffer);
-bool PlatformChannel_decodeValue(uint8_t** pbuffer, size_t* buffer_remaining, struct MessageChannelValue* value);
-bool PlatformChannel_freeValue(struct MessageChannelValue* p_value);
-bool PlatformChannel_sendMessage(char *channel, struct MessageChannelValue *argument);
-bool PlatformChannel_decodeMessage(size_t buffer_size, uint8_t *buffer, struct MethodCall **presult);
-bool PlatformChannel_respond(FlutterPlatformMessageResponseHandle *response_handle, struct MessageChannelValue *response);
-bool PlatformChannel_call(char *channel, char *method, struct MessageChannelValue *argument);
-bool PlatformChannel_decodeMethodCall(size_t buffer_size, uint8_t* buffer, struct MethodCall** presult);
-bool PlatformChannel_freeMethodCall(struct MethodCall **pmethodcall);
+/// Abstract Channel Object.
+/// Different properties are "valid" for different codecs:
+///   kStringCodec:
+///     - string_value is the raw byte data of a platform message, but with an additional null-byte at the end.
+///   kBinaryCodec:
+///     - binarydata is an array of the raw byte data of a platform message,
+///     - binarydata_size is the size of that byte data in uint8_t's.
+///   kJSONMessageCodec:
+///     - jsonmsgcodec_value
+///   kStdMsgCodecValue:
+///     - stdmsgcodec_value
+///   kStandardMethodCall:
+///     - "method" is the method you'd like to call, or the method that was called
+///       by flutter.
+///     - stdarg contains the argument to that method call.
+///   kJSONMethodCall:
+///     - "method" is the method you'd like to call, or the method that was called
+///       by flutter.
+///     - jsarg contains the argument to that method call.
+///   kStandardMethodCallResponse or kJSONMethodCallResponse:
+///     - "success" is whether the method call (send to flutter or received from flutter)
+///       was succesful, i.e. no errors ocurred.
+///       if success is false,
+///         - errorcode must be set (by you or by flutter) to point to a valid null-terminated string,
+///         - errormessage is either pointing to a valid null-terminated string or is set to NULL,
+///         - if the codec is kStandardMethodCallResponse,
+///             stderrordetails may be set to any StdMsgCodecValue or NULL.
+///         - if the codec is kJSONMethodCallResponse,
+///             jserrordetails may be set to any JSONMSgCodecValue or NULL.
+struct ChannelObject {
+    enum ChannelCodec codec;
+    union {
+        char                    *string_value;
+        struct {
+            size_t   binarydata_size;
+            uint8_t *binarydata;
+        };
+        struct JSONMsgCodecValue jsonmsgcodec_value;
+        struct StdMsgCodecValue  stdmsgcodec_value;
+        struct {
+            char *method;
+            union {
+                struct StdMsgCodecValue  stdarg;
+                struct JSONMsgCodecValue jsarg;
+            };
+        };
+        struct {
+            bool success;
+            union {
+                struct StdMsgCodecValue  stdresult;
+                struct JSONMsgCodecValue jsresult;
+            };
+            char *errorcode;
+            char *errormessage;
+            union {
+                struct StdMsgCodecValue stderrordetails;
+                struct JSONMsgCodecValue jserrordetails;
+            };
+        };
+    };
+};
+
+/// A Callback that is called when a response to a platform message you send to flutter
+/// arrives. "object" is the platform message decoded using the "codec" you gave to PlatformChannel_send,
+/// "userdata" is the userdata you gave to PlatformChannel_send.
+typedef int (*PlatformMessageResponseCallback)(struct ChannelObject *object, void *userdata);
+
+
+/// decodes a platform message (represented by `buffer` and `size`) as the given codec,
+/// and puts the result into object_out.
+/// This method will (in some cases) dynamically allocate memory,
+/// so you should always call PlatformChannel_free(object_out) when you don't need it anymore.
+/// 
+/// Additionally, PlatformChannel_decode currently "borrows" from the buffer, so if the buffer
+/// is freed by flutter, the contents of object_out will in many cases be bogus.
+/// If you'd like object_out to be persistent and not depend on the lifetime of the buffer,
+/// you'd have to manually deep-copy it.
+int PlatformChannel_decode(uint8_t *buffer, size_t size, enum ChannelCodec codec, struct ChannelObject *object_out);
+
+/// Encodes a generic ChannelObject into a buffer (that is, too, allocated by PlatformChannel_encode)
+/// A pointer to the buffer is put into buffer_out and the size of that buffer into size_out.
+/// The lifetime of the buffer is independent of the ChannelObject, so contents of the ChannelObject
+///   can be freed after the object was encoded.
+int PlatformChannel_encode(struct ChannelObject *object, uint8_t **buffer_out, size_t *size_out);
+
+/// Encodes a generic ChannelObject (anything, string/binary codec or Standard/JSON Method Calls and responses) as a platform message
+/// and sends it to flutter on channel `channel`
+/// When flutter responds to this message, it is automatically decoded using the codec given in `response_codec`.
+/// Then, on_response is called with the decoded ChannelObject and the userdata as an argument.
+/// Flutter _should_ always respond to platform messages, so it's okay if not calling your handler would cause a memory leak
+///   (since that should never happen)
+/// userdata can be NULL.
+int PlatformChannel_send(char *channel, struct ChannelObject *object, enum ChannelCodec response_codec, PlatformMessageResponseCallback on_response, void *userdata);
+
+/// Encodes a StandardMethodCodec method call as a platform message and sends it to flutter
+/// on channel `channel`. This is just a wrapper around PlatformChannel_send
+/// that builds the ChannelObject for you.
+/// The response_codec is kStandardMethodCallResponse. userdata can be NULL.
+int PlatformChannel_stdcall(char *channel, char *method, struct StdMsgCodecValue *argument, PlatformMessageResponseCallback on_response, void *userdata);
+
+/// Encodes a JSONMethodCodec method call as a platform message and sends it to flutter
+/// on channel `channel`. This is just a wrapper around PlatformChannel_send
+/// that builds the ChannelObject for you.
+/// The response_codec is kJSONMethodCallResponse. userdata can be NULL.
+int PlatformChannel_jsoncall(char *channel, char *method, struct JSONMsgCodecValue *argument, PlatformMessageResponseCallback on_response, void *userdata);
+
+/// Responds to a platform message. You can (of course) only respond once to a platform message,
+/// i.e. a FlutterPlatformMessageResponseHandle can only be used once.
+/// The codec of `response` can be any of the available codecs.
+int PlatformChannel_respond(FlutterPlatformMessageResponseHandle *handle, struct ChannelObject *response);
+
+/// Tells flutter that the platform message that was sent to you was not handled.
+///   (for example, there's no plugin that is using this channel, or there is a plugin
+///   but it doesn't want to respond.)
+/// You should always use this instead of not replying to a platform message, since not replying could cause a memory leak.
+/// When flutter receives this response, it will throw a MissingPluginException.
+///   For most channel used by the ServicesPlugin, this is not too bad since it
+///   specifies many of the channels used as OptionalMethodChannels. (which will silently catch the MissingPluginException)
+int PlatformChannel_respondNotImplemented(FlutterPlatformMessageResponseHandle *handle);
+
+/// Tells flutter that the method that was called caused an error.
+/// errorcode MUST be non-null, errormessage can be null.
+/// when codec is one of kStandardMethodCall, kStandardMethodCallResponse, kStandardMessageCodec:
+///   errordetails must either be NULL or a pointer to a struct StdMsgCodecValue.
+/// when codec is one of kJSONMethodCall, kJSONMethodCallResponse or kJSONMessageCodec:
+///   errordetails must either be NULL or a pointer to a struct JSONMsgCodecValue.
+int PlatformChannel_respondError(FlutterPlatformMessageResponseHandle *handle, enum ChannelCodec codec, char *errorcode, char *errormessage, void *errordetails);
+
+/// frees a ChannelObject that was decoded using PlatformChannel_decode.
+/// not freeing ChannelObjects may result in a memory leak.
+int PlatformChannel_free(struct ChannelObject *object);
+
+int json_findKey(struct JSONMsgCodecValue *object, char *key);
+struct JSONMsgCodecValue *json_get(struct JSONMsgCodecValue *object, char *key);
 
 #endif

--- a/src/platformchannel.h
+++ b/src/platformchannel.h
@@ -25,26 +25,26 @@ struct MessageChannelValue {
     MessageValueDiscriminator type;
     union {
         bool bool_value;
-        int32_t int_value;
-        int64_t long_value;
-        double double_value;
+        int32_t int32_value;
+        int64_t int64_value;
+        double float64_value;
         char* string_value;
         struct {
             size_t size;
             uint8_t* array;
-        } bytearray_value;
+        } uint8array_value;
         struct {
             size_t size;
             int32_t* array;
-        } intarray_value;
+        } int32array_value;
         struct {
             size_t size;
             int64_t* array;
-        } longarray_value;
+        } int64array_value;
         struct {
             size_t size;
             double* array;
-        } doublearray_value;
+        } float64array_value;
         struct {
             size_t size;
             struct MessageChannelValue* list;
@@ -65,9 +65,15 @@ struct MethodCall {
     struct MessageChannelValue argument;
 };
 
-bool MethodChannel_call(char* channel, char* method, struct MessageChannelValue* argument);
-bool MethodChannel_respond(FlutterPlatformMessageResponseHandle* response_handle, struct MessageChannelValue* response_value);
-bool MethodChannel_decode(size_t buffer_size, uint8_t* buffer, struct MethodCall** presult);
-bool MethodChannel_freeMethodCall(struct MethodCall** pmethodcall);
+bool PlatformChannel_calculateValueSizeInBuffer(struct MethodChannelValue* value, size_t* psize);
+bool PlatformChannel_writeValueToBuffer(struct MessageChannelValue *value, uint8_t **pbuffer);
+bool PlatformChannel_decodeValue(uint8_t** pbuffer, size_t* buffer_remaining, struct MessageChannelValue* value);
+bool PlatformChannel_freeValue(struct MessageChannelValue* p_value);
+bool PlatformChannel_sendMessage(char *channel, struct MessageChannelValue *argument);
+bool PlatformChannel_decodeMessage(size_t buffer_size, uint8_t *buffer, struct MethodCall **presult);
+bool PlatformChannel_respond(FlutterPlatformMessageResponseHandle *response_handle, struct MessageChannelValue *response);
+bool PlatformChannel_call(char *channel, char *method, struct MessageChannelValue *argument);
+bool PlatformChannel_decodeMethodCall(size_t buffer_size, uint8_t* buffer, struct MethodCall** presult);
+bool PlatformChannel_freeMethodCall(struct MethodCall **pmethodcall);
 
 #endif

--- a/src/pluginregistry.c
+++ b/src/pluginregistry.c
@@ -4,150 +4,143 @@
 #include "platformchannel.h"
 #include "pluginregistry.h"
 
+// hardcoded plugin headers
+#include "services-plugin.h"
+#include "testplugin.h"
+
+
+
+struct ChannelObjectReceiverData {
+	char *channel;
+	enum ChannelCodec codec;
+	ChannelObjectReceiveCallback callback;
+};
 struct FlutterPiPluginRegistry {
 	struct FlutterPiPlugin *plugins;
 	size_t plugin_count;
-	struct FlutterPiPluginRegistryCallbackListElement *callbacks;
+	struct ChannelObjectReceiverData *callbacks;
+	size_t callbacks_size;
 };
 
-struct FlutterPiPluginRegistryCallbackListElement {	// hopefully that full type name is not used very often.
-	struct FlutterPiPluginRegistryCallbackListElement *next;
-	char *channel;
-	void *userdata;
-	bool is_methodcall;
-	union {
-		FlutterPiMethodCallCallback      methodcall_callback;
-		FlutterPiPlatformMessageCallback message_callback;
-	};
+struct FlutterPiPlugin hardcoded_plugins[] = {
+	{.name = "services",     .init = Services_init, .deinit = Services_deinit},
+	{.name = "testplugin",   .init = TestPlugin_init, .deinit = TestPlugin_deinit}
 };
+struct FlutterPiPluginRegistry *pluginregistry;
 
 
-int PluginRegistry_init(struct FlutterPiPluginRegistry **pregistry) {
+int PluginRegistry_init() {
 	int ok;
 
-	*pregistry = NULL;
-	*pregistry = malloc(sizeof(struct FlutterPiPluginRegistry));
-	if (!(*pregistry)) return ENOMEM;
+	pluginregistry = malloc(sizeof(struct FlutterPiPluginRegistry));
+	if (!pluginregistry) return ENOMEM;
 
-	struct FlutterPiPluginRegistry *registry = *pregistry;
-	registry->plugins = hardcoded_plugins;
-	registry->plugin_count = sizeof(hardcoded_plugins) / sizeof(struct FlutterPiPlugin);
-
-	// load dynamic plugins
-	// nothing for now
-
-
-	for (int i = 0; i < registry->plugin_count; i++) {
-		ok = registry->plugins[i].init(registry, &(registry->plugins[i].userdata));
-		if (ok != 0) return ok;
-	}
-
-	return 0;
-}
-int PluginRegistry_onPlatformMessage(struct FlutterPiPluginRegistry *registry, FlutterPlatformMessage *message) {
-	struct FlutterPiPluginRegistryCallbackListElement *element = registry->callbacks;
-
-	for (element = registry->callbacks; element != NULL; element = element->next)
-		if (strcmp(element->channel, message->channel) == 0) break;
+	pluginregistry->callbacks_size = 20;
+	pluginregistry->callbacks = calloc(pluginregistry->callbacks_size, sizeof(struct ChannelObjectReceiverData));
 	
-	if (element != NULL) {
-		if (element->is_methodcall) {
-			// try decode platform message as method call
-			struct MethodCall *methodcall = NULL;
-			bool ok = PlatformChannel_decodeMethodCall(message->message_size, message->message, &methodcall);
-			if (!ok) return EBADMSG;
+	pluginregistry->plugins = hardcoded_plugins;
+	pluginregistry->plugin_count = sizeof(hardcoded_plugins) / sizeof(struct FlutterPiPlugin);
 
-			element->methodcall_callback(element->userdata, message->channel, methodcall);
+	// insert code for dynamically loading plugins here
 
-			PlatformChannel_freeMethodCall(&methodcall);
-		} else {
-			element->message_callback(element->userdata, message);
+	// call all the init methods for all plugins
+	for (int i = 0; i < pluginregistry->plugin_count; i++) {
+		if (pluginregistry->plugins[i].init) {
+			ok = pluginregistry->plugins[i].init();
+			if (ok != 0) return ok;
 		}
 	}
 
 	return 0;
 }
-int PluginRegistry_setPlatformMessageHandler(struct FlutterPiPluginRegistry *registry, char *channel,
-										 FlutterPiPlatformMessageCallback callback, void *userdata) {
+int PluginRegistry_onPlatformMessage(FlutterPlatformMessage *message) {
+	struct ChannelObject object;
+	int ok;
+
+	for (int i = 0; i < pluginregistry->callbacks_size; i++) {
+		if ((pluginregistry->callbacks[i].callback) && (strcmp(pluginregistry->callbacks[i].channel, message->channel) == 0)) {
+			ok = PlatformChannel_decode((uint8_t*) message->message, message->message_size, pluginregistry->callbacks[i].codec, &object);
+			if (ok != 0) return ok;
+
+			pluginregistry->callbacks[i].callback((char*) message->channel, &object, (FlutterPlatformMessageResponseHandle*) message->response_handle);
+
+			PlatformChannel_free(&object);
+			return 0;
+		}
+	}
+
+	// we didn't find a callback for the specified channel.
+	// just respond with a null buffer to tell the VM-side
+	// that the feature is not implemented.
+
+	return PlatformChannel_respondNotImplemented((FlutterPlatformMessageResponseHandle *) message->response_handle);
+}
+int PluginRegistry_setReceiver(char *channel, enum ChannelCodec codec, ChannelObjectReceiveCallback callback) {
+	/// the index in 'callback' of the ChannelObjectReceiverData that will be added / updated.
+	int index = -1;
+
+	/// find the index with channel name 'channel', or else, the first unoccupied index.
+	for (int i = 0; i < pluginregistry->callbacks_size; i++) {
+		if (pluginregistry->callbacks[i].channel == NULL) {
+			if (index == -1) {
+				index = i;
+			}
+		} else if (strcmp(channel, pluginregistry->callbacks[i].channel) == 0) {
+			index = i;
+			break;
+		}
+	}
 	
-	struct FlutterPiPluginRegistryCallbackListElement *element;
-	for (element = registry->callbacks; element != NULL; element = element->next)
-		if (strcmp(element->channel, channel) == 0) break;
-	
-	if (element != NULL) {
-		// change the behaviour of the existing handler
+	/// no matching or unoccupied index found.
+	if (index == -1) {
+		if (!callback) return 0;
+		
+		/// expand array
+		size_t currentsize = pluginregistry->callbacks_size * sizeof(struct ChannelObjectReceiverData);
+		
+		pluginregistry->callbacks = realloc(pluginregistry->callbacks, 2 * currentsize);
+		memset(&pluginregistry->callbacks[pluginregistry->callbacks_size], currentsize, 0);
 
-		element->is_methodcall = false;
-		element->message_callback = callback;
-		element->userdata = userdata;
-		return 0;
-	} else {
-		// new handler
+		index = pluginregistry->callbacks_size;
+		pluginregistry->callbacks_size = 2*pluginregistry->callbacks_size;
+	}
 
-		element = malloc(sizeof(struct FlutterPiPluginRegistryCallbackListElement));
-		if (!element) return ENOMEM;
+	if (callback) {
+		char *channelCopy = malloc(strlen(channel) +1);
+		if (!channelCopy) return ENOMEM;
+		strcpy(channelCopy, channel);
 
-		element->channel = calloc(strlen(channel) +1, sizeof(char));
-		if (!element->channel) return ENOMEM;
-
-		strcpy(element->channel, channel);
-
-		element->is_methodcall = false;
-		element->message_callback = callback;
-		element->userdata = userdata;
-		element->next = registry->callbacks;
-
-		registry->callbacks = element;
+		pluginregistry->callbacks[index].channel = channelCopy;
+		pluginregistry->callbacks[index].codec = codec;
+		pluginregistry->callbacks[index].callback = callback;
+	} else if (pluginregistry->callbacks[index].callback) {
+		free(pluginregistry->callbacks[index].channel);
+		pluginregistry->callbacks[index].channel = NULL;
+		pluginregistry->callbacks[index].callback = NULL;
 	}
 
 	return 0;
-}
-int PluginRegistry_setMethodCallHandler(struct FlutterPiPluginRegistry *registry, char *channel,
-										FlutterPiMethodCallCallback callback, void *userdata) {
-	struct FlutterPiPluginRegistryCallbackListElement *element;
-
-	for (element = registry->callbacks; element != NULL; element = element->next)
-		if (strcmp(element->channel, channel) == 0) break;
 	
-	if (element != NULL) {
-		// change the behaviour of the existing handler
-
-		element->is_methodcall = true;
-		element->methodcall_callback = callback;
-		element->userdata = userdata;
-		return 0;
-	} else {
-		// new handler
-
-		element = malloc(sizeof(struct FlutterPiPluginRegistryCallbackListElement));
-		if (!element) return ENOMEM;
-
-		element->channel = calloc(strlen(channel) +1, sizeof(char));
-		if (!element->channel) return ENOMEM;
-
-		strcpy(element->channel, channel);
-
-		element->is_methodcall = true;
-		element->methodcall_callback = callback;
-		element->userdata = userdata;
-		element->next = registry->callbacks;
-
-		registry->callbacks = element;
-	}
-
-	return 0;
 }
-int PluginRegistry_deinit(struct FlutterPiPluginRegistry **pregistry) {
-	struct FlutterPiPluginRegistryCallbackListElement *element = (*pregistry)->callbacks, *t = NULL;
-
-	while (element != NULL) {
-		free(element->channel);
-
-		t = element;
-		element = element->next;
-		free(t);
+int PluginRegistry_deinit() {
+	int i, ok;
+	
+	/// call each plugins 'deinit'
+	for (i = 0; i < pluginregistry->plugin_count; i++) {
+		if (pluginregistry->plugins[i].deinit) {
+			ok = pluginregistry->plugins[i].deinit();
+			if (ok != 0) return ok;
+		}
 	}
 
-	free(*pregistry);
-	*pregistry = NULL;
+	/// free all the channel names from the callback list.
+	for (int i=0; i < pluginregistry->callbacks_size; i++) {
+		if (pluginregistry->callbacks[i].channel)
+			free(pluginregistry->callbacks[i].channel);
+	}
+
+	/// free the rest
+	free(pluginregistry->callbacks);
+	free(pluginregistry);
+	pluginregistry = NULL;
 }

--- a/src/pluginregistry.c
+++ b/src/pluginregistry.c
@@ -9,44 +9,46 @@
 #include "testplugin.h"
 
 
-
 struct ChannelObjectReceiverData {
 	char *channel;
 	enum ChannelCodec codec;
 	ChannelObjectReceiveCallback callback;
 };
-struct FlutterPiPluginRegistry {
+struct {
 	struct FlutterPiPlugin *plugins;
 	size_t plugin_count;
 	struct ChannelObjectReceiverData *callbacks;
 	size_t callbacks_size;
-};
+} pluginregistry;
 
+/// array of plugins that are statically included in flutter-pi.
 struct FlutterPiPlugin hardcoded_plugins[] = {
 	{.name = "services",     .init = Services_init, .deinit = Services_deinit},
+
+#ifdef INCLUDE_TESTPLUGIN	
 	{.name = "testplugin",   .init = TestPlugin_init, .deinit = TestPlugin_deinit}
+#endif
 };
-struct FlutterPiPluginRegistry *pluginregistry;
+size_t hardcoded_plugins_count;
 
 
 int PluginRegistry_init() {
 	int ok;
 
-	pluginregistry = malloc(sizeof(struct FlutterPiPluginRegistry));
-	if (!pluginregistry) return ENOMEM;
+	memset(&pluginregistry, 0, sizeof(pluginregistry));
 
-	pluginregistry->callbacks_size = 20;
-	pluginregistry->callbacks = calloc(pluginregistry->callbacks_size, sizeof(struct ChannelObjectReceiverData));
+	pluginregistry.callbacks_size = 20;
+	pluginregistry.callbacks = calloc(pluginregistry.callbacks_size, sizeof(struct ChannelObjectReceiverData));
 	
-	pluginregistry->plugins = hardcoded_plugins;
-	pluginregistry->plugin_count = sizeof(hardcoded_plugins) / sizeof(struct FlutterPiPlugin);
+	pluginregistry.plugins = hardcoded_plugins;
+	pluginregistry.plugin_count = sizeof(hardcoded_plugins) / sizeof(struct FlutterPiPlugin);
 
 	// insert code for dynamically loading plugins here
 
 	// call all the init methods for all plugins
-	for (int i = 0; i < pluginregistry->plugin_count; i++) {
-		if (pluginregistry->plugins[i].init) {
-			ok = pluginregistry->plugins[i].init();
+	for (int i = 0; i < pluginregistry.plugin_count; i++) {
+		if (pluginregistry.plugins[i].init) {
+			ok = pluginregistry.plugins[i].init();
 			if (ok != 0) return ok;
 		}
 	}
@@ -57,12 +59,12 @@ int PluginRegistry_onPlatformMessage(FlutterPlatformMessage *message) {
 	struct ChannelObject object;
 	int ok;
 
-	for (int i = 0; i < pluginregistry->callbacks_size; i++) {
-		if ((pluginregistry->callbacks[i].callback) && (strcmp(pluginregistry->callbacks[i].channel, message->channel) == 0)) {
-			ok = PlatformChannel_decode((uint8_t*) message->message, message->message_size, pluginregistry->callbacks[i].codec, &object);
+	for (int i = 0; i < pluginregistry.callbacks_size; i++) {
+		if ((pluginregistry.callbacks[i].callback) && (strcmp(pluginregistry.callbacks[i].channel, message->channel) == 0)) {
+			ok = PlatformChannel_decode((uint8_t*) message->message, message->message_size, pluginregistry.callbacks[i].codec, &object);
 			if (ok != 0) return ok;
 
-			pluginregistry->callbacks[i].callback((char*) message->channel, &object, (FlutterPlatformMessageResponseHandle*) message->response_handle);
+			pluginregistry.callbacks[i].callback((char*) message->channel, &object, (FlutterPlatformMessageResponseHandle*) message->response_handle);
 
 			PlatformChannel_free(&object);
 			return 0;
@@ -80,12 +82,12 @@ int PluginRegistry_setReceiver(char *channel, enum ChannelCodec codec, ChannelOb
 	int index = -1;
 
 	/// find the index with channel name 'channel', or else, the first unoccupied index.
-	for (int i = 0; i < pluginregistry->callbacks_size; i++) {
-		if (pluginregistry->callbacks[i].channel == NULL) {
+	for (int i = 0; i < pluginregistry.callbacks_size; i++) {
+		if (pluginregistry.callbacks[i].channel == NULL) {
 			if (index == -1) {
 				index = i;
 			}
-		} else if (strcmp(channel, pluginregistry->callbacks[i].channel) == 0) {
+		} else if (strcmp(channel, pluginregistry.callbacks[i].channel) == 0) {
 			index = i;
 			break;
 		}
@@ -96,13 +98,13 @@ int PluginRegistry_setReceiver(char *channel, enum ChannelCodec codec, ChannelOb
 		if (!callback) return 0;
 		
 		/// expand array
-		size_t currentsize = pluginregistry->callbacks_size * sizeof(struct ChannelObjectReceiverData);
+		size_t currentsize = pluginregistry.callbacks_size * sizeof(struct ChannelObjectReceiverData);
 		
-		pluginregistry->callbacks = realloc(pluginregistry->callbacks, 2 * currentsize);
-		memset(&pluginregistry->callbacks[pluginregistry->callbacks_size], currentsize, 0);
+		pluginregistry.callbacks = realloc(pluginregistry.callbacks, 2 * currentsize);
+		memset(&pluginregistry.callbacks[pluginregistry.callbacks_size], currentsize, 0);
 
-		index = pluginregistry->callbacks_size;
-		pluginregistry->callbacks_size = 2*pluginregistry->callbacks_size;
+		index = pluginregistry.callbacks_size;
+		pluginregistry.callbacks_size = 2*pluginregistry.callbacks_size;
 	}
 
 	if (callback) {
@@ -110,13 +112,13 @@ int PluginRegistry_setReceiver(char *channel, enum ChannelCodec codec, ChannelOb
 		if (!channelCopy) return ENOMEM;
 		strcpy(channelCopy, channel);
 
-		pluginregistry->callbacks[index].channel = channelCopy;
-		pluginregistry->callbacks[index].codec = codec;
-		pluginregistry->callbacks[index].callback = callback;
-	} else if (pluginregistry->callbacks[index].callback) {
-		free(pluginregistry->callbacks[index].channel);
-		pluginregistry->callbacks[index].channel = NULL;
-		pluginregistry->callbacks[index].callback = NULL;
+		pluginregistry.callbacks[index].channel = channelCopy;
+		pluginregistry.callbacks[index].codec = codec;
+		pluginregistry.callbacks[index].callback = callback;
+	} else if (pluginregistry.callbacks[index].callback) {
+		free(pluginregistry.callbacks[index].channel);
+		pluginregistry.callbacks[index].channel = NULL;
+		pluginregistry.callbacks[index].callback = NULL;
 	}
 
 	return 0;
@@ -126,21 +128,19 @@ int PluginRegistry_deinit() {
 	int i, ok;
 	
 	/// call each plugins 'deinit'
-	for (i = 0; i < pluginregistry->plugin_count; i++) {
-		if (pluginregistry->plugins[i].deinit) {
-			ok = pluginregistry->plugins[i].deinit();
+	for (i = 0; i < pluginregistry.plugin_count; i++) {
+		if (pluginregistry.plugins[i].deinit) {
+			ok = pluginregistry.plugins[i].deinit();
 			if (ok != 0) return ok;
 		}
 	}
 
 	/// free all the channel names from the callback list.
-	for (int i=0; i < pluginregistry->callbacks_size; i++) {
-		if (pluginregistry->callbacks[i].channel)
-			free(pluginregistry->callbacks[i].channel);
+	for (int i=0; i < pluginregistry.callbacks_size; i++) {
+		if (pluginregistry.callbacks[i].channel)
+			free(pluginregistry.callbacks[i].channel);
 	}
 
 	/// free the rest
-	free(pluginregistry->callbacks);
-	free(pluginregistry);
-	pluginregistry = NULL;
+	free(pluginregistry.callbacks);
 }

--- a/src/pluginregistry.c
+++ b/src/pluginregistry.c
@@ -1,0 +1,153 @@
+#include <sys/errno.h>
+#include <string.h>
+
+#include "platformchannel.h"
+#include "pluginregistry.h"
+
+struct FlutterPiPluginRegistry {
+	struct FlutterPiPlugin *plugins;
+	size_t plugin_count;
+	struct FlutterPiPluginRegistryCallbackListElement *callbacks;
+};
+
+struct FlutterPiPluginRegistryCallbackListElement {	// hopefully that full type name is not used very often.
+	struct FlutterPiPluginRegistryCallbackListElement *next;
+	char *channel;
+	void *userdata;
+	bool is_methodcall;
+	union {
+		FlutterPiMethodCallCallback      methodcall_callback;
+		FlutterPiPlatformMessageCallback message_callback;
+	};
+};
+
+
+int PluginRegistry_init(struct FlutterPiPluginRegistry **pregistry) {
+	int ok;
+
+	*pregistry = NULL;
+	*pregistry = malloc(sizeof(struct FlutterPiPluginRegistry));
+	if (!(*pregistry)) return ENOMEM;
+
+	struct FlutterPiPluginRegistry *registry = *pregistry;
+	registry->plugins = hardcoded_plugins;
+	registry->plugin_count = sizeof(hardcoded_plugins) / sizeof(struct FlutterPiPlugin);
+
+	// load dynamic plugins
+	// nothing for now
+
+
+	for (int i = 0; i < registry->plugin_count; i++) {
+		ok = registry->plugins[i].init(registry, &(registry->plugins[i].userdata));
+		if (ok != 0) return ok;
+	}
+
+	return 0;
+}
+int PluginRegistry_onPlatformMessage(struct FlutterPiPluginRegistry *registry, FlutterPlatformMessage *message) {
+	struct FlutterPiPluginRegistryCallbackListElement *element = registry->callbacks;
+
+	for (element = registry->callbacks; element != NULL; element = element->next)
+		if (strcmp(element->channel, message->channel) == 0) break;
+	
+	if (element != NULL) {
+		if (element->is_methodcall) {
+			// try decode platform message as method call
+			struct MethodCall *methodcall = NULL;
+			bool ok = PlatformChannel_decodeMethodCall(message->message_size, message->message, &methodcall);
+			if (!ok) return EBADMSG;
+
+			element->methodcall_callback(element->userdata, message->channel, methodcall);
+
+			PlatformChannel_freeMethodCall(&methodcall);
+		} else {
+			element->message_callback(element->userdata, message);
+		}
+	}
+
+	return 0;
+}
+int PluginRegistry_setPlatformMessageHandler(struct FlutterPiPluginRegistry *registry, char *channel,
+										 FlutterPiPlatformMessageCallback callback, void *userdata) {
+	
+	struct FlutterPiPluginRegistryCallbackListElement *element;
+	for (element = registry->callbacks; element != NULL; element = element->next)
+		if (strcmp(element->channel, channel) == 0) break;
+	
+	if (element != NULL) {
+		// change the behaviour of the existing handler
+
+		element->is_methodcall = false;
+		element->message_callback = callback;
+		element->userdata = userdata;
+		return 0;
+	} else {
+		// new handler
+
+		element = malloc(sizeof(struct FlutterPiPluginRegistryCallbackListElement));
+		if (!element) return ENOMEM;
+
+		element->channel = calloc(strlen(channel) +1, sizeof(char));
+		if (!element->channel) return ENOMEM;
+
+		strcpy(element->channel, channel);
+
+		element->is_methodcall = false;
+		element->message_callback = callback;
+		element->userdata = userdata;
+		element->next = registry->callbacks;
+
+		registry->callbacks = element;
+	}
+
+	return 0;
+}
+int PluginRegistry_setMethodCallHandler(struct FlutterPiPluginRegistry *registry, char *channel,
+										FlutterPiMethodCallCallback callback, void *userdata) {
+	struct FlutterPiPluginRegistryCallbackListElement *element;
+
+	for (element = registry->callbacks; element != NULL; element = element->next)
+		if (strcmp(element->channel, channel) == 0) break;
+	
+	if (element != NULL) {
+		// change the behaviour of the existing handler
+
+		element->is_methodcall = true;
+		element->methodcall_callback = callback;
+		element->userdata = userdata;
+		return 0;
+	} else {
+		// new handler
+
+		element = malloc(sizeof(struct FlutterPiPluginRegistryCallbackListElement));
+		if (!element) return ENOMEM;
+
+		element->channel = calloc(strlen(channel) +1, sizeof(char));
+		if (!element->channel) return ENOMEM;
+
+		strcpy(element->channel, channel);
+
+		element->is_methodcall = true;
+		element->methodcall_callback = callback;
+		element->userdata = userdata;
+		element->next = registry->callbacks;
+
+		registry->callbacks = element;
+	}
+
+	return 0;
+}
+int PluginRegistry_deinit(struct FlutterPiPluginRegistry **pregistry) {
+	struct FlutterPiPluginRegistryCallbackListElement *element = (*pregistry)->callbacks, *t = NULL;
+
+	while (element != NULL) {
+		free(element->channel);
+
+		t = element;
+		element = element->next;
+		free(t);
+	}
+
+	free(*pregistry);
+	*pregistry = NULL;
+}

--- a/src/pluginregistry.h
+++ b/src/pluginregistry.h
@@ -1,31 +1,31 @@
+#ifndef FLUTTER_PI_REGISTRY_H_
+#define FLUTTER_PI_REGISTRY_H_ 1
+
 #include <stdbool.h>
 #include <stdlib.h>
+#include <flutter_embedder.h>
 
 #include "platformchannel.h"
 
-#ifndef FLUTTER_PI_REGISTRY_H_
-#define FLUTTER_PI_REGISTRY_H_
+typedef int (*InitDeinitCallback)(void);
+typedef int (*ChannelObjectReceiveCallback)(char*, struct ChannelObject*, FlutterPlatformMessageResponseHandle *responsehandle);
 
-typedef bool (*FlutterPiPluginRegistryCallback)(struct FlutterPiPluginRegistry *registry, void **userdata);
-typedef bool (*FlutterPiMethodCallCallback)(void *userdata, char *channel, struct MethodCall *methodcall);
-typedef bool (*FlutterPiPlatformMessageCallback)(void *userdata, FlutterPlatformMessage *message);
 struct FlutterPiPluginRegistry;
 
 struct FlutterPiPlugin {
     const char const* name;
-	FlutterPiPluginRegistryCallback init;
-	FlutterPiPluginRegistryCallback deinit;
-    void *userdata;
+	InitDeinitCallback init;
+	InitDeinitCallback deinit;
 };
 
-const struct FlutterPiPlugin hardcoded_plugins[] = {
-    {.name="connectivity", .init=NULL, .deinit=NULL, .userdata=NULL}
-};
 
-extern int PluginRegistry_init(struct FlutterPiPluginRegistry **registry);
-extern int PluginRegistry_onMethodCall(struct FlutterPiPluginRegistry *registry, char *channel, struct MethodCall *methodcall);
-extern int PluginRegistry_setMethodCallHandler(struct FlutterPiPluginRegistry *registry, char *methodchannel,
-                                               FlutterPiMethodCallCallback callback,  void *userdata);
-extern int PluginRegistry_deinit(struct FlutterPiPluginRegistry **registry);
+extern int hardcoded_plugins_count;
+extern struct FlutterPiPlugin hardcoded_plugins[];
+extern struct FlutterPiPluginRegistry *pluginregistry;
+
+int PluginRegistry_init();
+int PluginRegistry_onPlatformMessage(FlutterPlatformMessage *message);
+int PluginRegistry_setReceiver(char *channel, enum ChannelCodec codec, ChannelObjectReceiveCallback callback);
+int PluginRegistry_deinit();
 
 #endif

--- a/src/pluginregistry.h
+++ b/src/pluginregistry.h
@@ -1,0 +1,31 @@
+#include <stdbool.h>
+#include <stdlib.h>
+
+#include "platformchannel.h"
+
+#ifndef FLUTTER_PI_REGISTRY_H_
+#define FLUTTER_PI_REGISTRY_H_
+
+typedef bool (*FlutterPiPluginRegistryCallback)(struct FlutterPiPluginRegistry *registry, void **userdata);
+typedef bool (*FlutterPiMethodCallCallback)(void *userdata, char *channel, struct MethodCall *methodcall);
+typedef bool (*FlutterPiPlatformMessageCallback)(void *userdata, FlutterPlatformMessage *message);
+struct FlutterPiPluginRegistry;
+
+struct FlutterPiPlugin {
+    const char const* name;
+	FlutterPiPluginRegistryCallback init;
+	FlutterPiPluginRegistryCallback deinit;
+    void *userdata;
+};
+
+const struct FlutterPiPlugin hardcoded_plugins[] = {
+    {.name="connectivity", .init=NULL, .deinit=NULL, .userdata=NULL}
+};
+
+extern int PluginRegistry_init(struct FlutterPiPluginRegistry **registry);
+extern int PluginRegistry_onMethodCall(struct FlutterPiPluginRegistry *registry, char *channel, struct MethodCall *methodcall);
+extern int PluginRegistry_setMethodCallHandler(struct FlutterPiPluginRegistry *registry, char *methodchannel,
+                                               FlutterPiMethodCallCallback callback,  void *userdata);
+extern int PluginRegistry_deinit(struct FlutterPiPluginRegistry **registry);
+
+#endif

--- a/src/pluginregistry.h
+++ b/src/pluginregistry.h
@@ -7,11 +7,31 @@
 
 #include "platformchannel.h"
 
+/// Callback for Initialization or Deinitialization.
+/// Return value is 0 for success, or anything else for an error
+///   (uses the errno error codes)
 typedef int (*InitDeinitCallback)(void);
-typedef int (*ChannelObjectReceiveCallback)(char*, struct ChannelObject*, FlutterPlatformMessageResponseHandle *responsehandle);
 
-struct FlutterPiPluginRegistry;
+/// A Callback that gets called when a platform message
+/// arrives on a channel you registered it with.
+/// channel is the method channel that received a platform message,
+/// object is the object that is the result of automatically decoding
+/// the platform message using the codec given to PluginRegistry_setReceiver.
+/// BE AWARE that object->type can be kNotImplemented, REGARDLESS of the codec
+///   passed to PluginRegistry_setReceiver.
+typedef int (*ChannelObjectReceiveCallback)(char *channel, struct ChannelObject *object, FlutterPlatformMessageResponseHandle *responsehandle);
 
+/// details of a plugin for flutter-pi.
+/// All plugins are initialized (i.e. get their "init" callbacks called)
+///   when PluginRegistry_init() is called by flutter-pi.
+///   In the init callback, you probably want to do stuff like
+///   register callbacks for some method channels your plugin uses,
+///   or dynamically allocate memory for your plugin if you need to.
+///   PluginRegistry_init() and thus every plugins init is called
+///   BEFORE the flutter engine is set up and running. The "engine"
+///   global may even be NULL at the time "init" is called. Sending flutter messages
+///   will probably cause the application to crash.
+/// deinit is also called AFTER the engine is shut down.
 struct FlutterPiPlugin {
     const char const* name;
 	InitDeinitCallback init;
@@ -19,13 +39,14 @@ struct FlutterPiPlugin {
 };
 
 
-extern int hardcoded_plugins_count;
-extern struct FlutterPiPlugin hardcoded_plugins[];
-extern struct FlutterPiPluginRegistry *pluginregistry;
-
 int PluginRegistry_init();
 int PluginRegistry_onPlatformMessage(FlutterPlatformMessage *message);
+
+/// Sets the callback that should be called when a platform message arrives on channel "channel",
+/// and the codec used to automatically decode the platform message.
+/// Call this method with NULL as the callback parameter to remove the current listener on that channel.
 int PluginRegistry_setReceiver(char *channel, enum ChannelCodec codec, ChannelObjectReceiveCallback callback);
+
 int PluginRegistry_deinit();
 
 #endif

--- a/src/services-plugin.c
+++ b/src/services-plugin.c
@@ -1,0 +1,162 @@
+#include <ctype.h>
+#include <errno.h>
+
+#include "pluginregistry.h"
+#include "services-plugin.h"
+
+struct {
+    char label[256];
+    uint32_t primaryColor;  // ARGB8888 (blue is the lowest byte)
+    char isolateId[32];
+} ServicesPlugin = {0};
+
+
+int Services_onReceiveNavigation(char *channel, struct ChannelObject *object, FlutterPlatformMessageResponseHandle *responsehandle) {
+    return PlatformChannel_respondNotImplemented(responsehandle);
+}
+
+int Services_onReceiveIsolate(char *channel, struct ChannelObject *object, FlutterPlatformMessageResponseHandle *responsehandle) {
+    memset(&(ServicesPlugin.isolateId), sizeof(ServicesPlugin.isolateId), 0);
+    memcpy(ServicesPlugin.isolateId, object->binarydata, object->binarydata_size);
+    
+    return PlatformChannel_respondNotImplemented(responsehandle);
+}
+
+int Services_onReceivePlatform(char *channel, struct ChannelObject *object, FlutterPlatformMessageResponseHandle *responsehandle) {
+    struct JSONMsgCodecValue *value;
+    struct JSONMsgCodecValue *arg = &(object->jsarg);
+    int ok;
+    
+    if (strcmp(object->method, "Clipboard.setData") == 0) {
+        /*
+         *  Clipboard.setData(Map data)
+         *      Places the data from the text entry of the argument,
+         *      which must be a Map, onto the system clipboard.
+         */
+    } else if (strcmp(object->method, "Clipboard.getData") == 0) {
+        /*
+         *  Clipboard.getData(String format)
+         *      Returns the data that has the format specified in the argument
+         *      from the system clipboard. The only currently supported is "text/plain".
+         *      The result is a Map with a single key, "text".
+         */ 
+    } else if (strcmp(object->method, "HapticFeedback.vibrate") == 0) {
+        /*
+         *  HapticFeedback.vibrate(void)
+         *      Triggers a system-default haptic response.
+         */
+    } else if (strcmp(object->method, "SystemSound.play") == 0) {
+        /*
+         *  SystemSound.play(String soundName)
+         *      Triggers a system audio effect. The argument must
+         *      be a String describing the desired effect; currently only "click" is
+         *      supported.
+         */
+    } else if (strcmp(object->method, "SystemChrome.setPreferredOrientations") == 0) {
+        /*
+         *  SystemChrome.setPreferredOrientations(DeviceOrientation[])
+         *      Informs the operating system of the desired orientation of the display. The argument is a [List] of
+         *      values which are string representations of values of the [DeviceOrientation] enum.
+         * 
+         *  enum DeviceOrientation {
+         *      portraitUp, landscapeLeft, portraitDown, landscapeRight
+         *  }
+         */
+    } else if (strcmp(object->method, "SystemChrome.setApplicationSwitcherDescription") == 0) {
+        /*
+         *  SystemChrome.setApplicationSwitcherDescription(Map description)
+         *      Informs the operating system of the desired label and color to be used
+         *      to describe the application in any system-level application lists (e.g application switchers)
+         *      The argument is a Map with two keys, "label" giving a string description,
+         *      and "primaryColor" giving a 32 bit integer value (the lower eight bits being the blue channel,
+         *      the next eight bits being the green channel, the next eight bits being the red channel,
+         *      and the high eight bits being set, as from Color.value for an opaque color).
+         *      The "primaryColor" can also be zero to indicate that the system default should be used.
+         */
+        
+        /*
+        value = json_get(arg, "label");
+        if (value && (value->type == kJSString))
+            snprintf(ServicesPlugin.label, sizeof(ServicesPlugin.label), "%s", value->string_value);
+        
+        printf("ServicesPlugin responding with true\n");
+        return PlatformChannel_respond(responsehandle, &(struct ChannelObject) {
+            .codec = kStringCodec,
+            .string_value = "[true]"
+        });
+        */
+    } else if (strcmp(object->method, "SystemChrome.setEnabledSystemUIOverlays") == 0) {
+        /*
+         *  SystemChrome.setEnabledSystemUIOverlays(List overlays)
+         *      Specifies the set of system overlays to have visible when the application
+         *      is running. The argument is a List of values which are
+         *      string representations of values of the SystemUIOverlay enum.
+         * 
+         *  enum SystemUIOverlay {
+         *      top, bottom
+         *  }
+         * 
+         */
+    } else if (strcmp(object->method, "SystemChrome.restoreSystemUIOverlays") == 0) {
+        /*
+         * SystemChrome.restoreSystemUIOverlays(void)
+         */
+    } else if (strcmp(object->method, "SystemChrome.setSystemUIOverlayStyle") == 0) {
+        /*  
+         *  SystemChrome.setSystemUIOverlayStyle(struct SystemUIOverlayStyle)
+         * 
+         *  enum Brightness:
+         *      light, dark
+         * 
+         *  struct SystemUIOverlayStyle:
+         *      systemNavigationBarColor: null / uint32
+         *      statusBarColor: null / uint32
+         *      statusBarIconBrightness: null / Brightness
+         *      statusBarBrightness: null / Brightness
+         *      systemNavigationBarIconBrightness: null / Brightness
+         */
+    } else if (strcmp(object->method, "SystemNavigator.pop")) {
+        printf("flutter requested application exit\n");
+    }
+
+    return PlatformChannel_respondNotImplemented(responsehandle);
+}
+
+int Services_onReceiveAccessibility(char *channel, struct ChannelObject *object, FlutterPlatformMessageResponseHandle *responsehandle) {
+    return PlatformChannel_respondNotImplemented(responsehandle);
+}
+
+
+int Services_init(void) {
+    int ok;
+
+    ok = PluginRegistry_setReceiver("flutter/navigation", kJSONMethodCall, Services_onReceiveNavigation);
+    if (ok != 0) {
+        printf("Could not set flutter/navigation ChannelObject receiver: %s\n", strerror(ok));
+        return ok;
+    }
+
+    ok = PluginRegistry_setReceiver("flutter/isolate", kBinaryCodec, Services_onReceiveIsolate);
+    if (ok != 0) {
+        printf("Could not set flutter/isolate  ChannelObject receiver: %s\n", strerror(ok));
+        return ok;
+    }
+
+    ok = PluginRegistry_setReceiver("flutter/platform", kJSONMethodCall, Services_onReceivePlatform);
+    if (ok != 0) {
+        printf("Could not set flutter/platform ChannelObject receiver: %s\n", strerror(ok));
+        return ok;
+    }
+
+    ok = PluginRegistry_setReceiver("flutter/accessibility", kBinaryCodec, Services_onReceiveAccessibility);
+    if (ok != 0) {
+        printf("Could not set flutter/accessibility  ChannelObject receiver: %s\n", strerror(ok));
+        return ok;
+    }
+
+    printf("Initialized Services plugin.\n");
+}
+
+int Services_deinit(void) {
+    printf("Deinitialized Services plugin.\n");
+}

--- a/src/services-plugin.c
+++ b/src/services-plugin.c
@@ -74,17 +74,17 @@ int Services_onReceivePlatform(char *channel, struct ChannelObject *object, Flut
          *      The "primaryColor" can also be zero to indicate that the system default should be used.
          */
         
-        /*
-        value = json_get(arg, "label");
+        value = jsobject_get(arg, "label");
         if (value && (value->type == kJSString))
             snprintf(ServicesPlugin.label, sizeof(ServicesPlugin.label), "%s", value->string_value);
         
-        printf("ServicesPlugin responding with true\n");
         return PlatformChannel_respond(responsehandle, &(struct ChannelObject) {
-            .codec = kStringCodec,
-            .string_value = "[true]"
+            .codec = kJSONMethodCallResponse,
+            .success = true,
+            .jsresult = {
+                .type = kNull
+            }
         });
-        */
     } else if (strcmp(object->method, "SystemChrome.setEnabledSystemUIOverlays") == 0) {
         /*
          *  SystemChrome.setEnabledSystemUIOverlays(List overlays)

--- a/src/services-plugin.h
+++ b/src/services-plugin.h
@@ -1,0 +1,10 @@
+#ifndef _SERVICES_PLUGIN_H
+#define _SERVICES_PLUGIN_H
+
+#include <stdio.h>
+#include <string.h>
+
+int Services_init(void);
+int Services_deinit(void);
+
+#endif

--- a/src/testplugin.c
+++ b/src/testplugin.c
@@ -145,6 +145,11 @@ int printStd(struct StdMsgCodecValue *value, int indent) {
 int TestPlugin_onReceiveResponseJSON(struct ChannelObject *object, void *userdata) {
     uint64_t dt = FlutterEngineGetCurrentTime() - *((uint64_t*) userdata);
     free(userdata);
+    
+    if (object->codec == kNotImplemented) {
+        printf("channel " TESTPLUGIN_CHANNEL_JSON " not implented on flutter side\n");
+        return 0;
+    }
 
     if (object->success) {
         printf("TestPlugin_onReceiveResponseJSON(dt: %lluns)\n"
@@ -197,6 +202,11 @@ int TestPlugin_sendJSON() {
 int TestPlugin_onReceiveResponseStd(struct ChannelObject *object, void *userdata) {
     uint64_t dt = FlutterEngineGetCurrentTime() - *((uint64_t*) userdata);
     free(userdata);
+
+    if (object->codec == kNotImplemented) {
+        printf("channel " TESTPLUGIN_CHANNEL_STD " not implented on flutter side\n");
+        return 0;
+    }
 
     if (object->success) {
         printf("TestPlugin_onReceiveResponseStd(dt: %lluns)\n"

--- a/src/testplugin.c
+++ b/src/testplugin.c
@@ -1,0 +1,299 @@
+#include <stdio.h>
+#include <string.h>
+#include <inttypes.h>
+
+#include "pluginregistry.h"
+
+#define TESTPLUGIN_CHANNEL_JSON "plugins.flutter-pi.io/testjson"
+#define TESTPLUGIN_CHANNEL_STD "plugins.flutter-pi.io/teststd"
+#define INDENT_STRING "                    "
+
+int __printJSON(struct JSONMsgCodecValue *value, int indent) {
+    switch (value->type) {
+        case kJSNull:
+            printf("null");
+            break;
+        case kJSTrue:
+            printf("true");
+            break;
+        case kJSFalse:
+            printf("false");
+            break;
+        case kJSNumber:
+            printf("%f", value->number_value);
+            break;
+        case kJSString:
+            printf("\"%s\"", value->string_value);
+            break;
+        case kJSArray:
+            printf("[\n");
+            for (int i = 0; i < value->size; i++) {
+                printf("%.*s", indent + 2, INDENT_STRING);
+                __printJSON(&(value->array[i]), indent + 2);
+                if (i+1 != value->size) printf(",\n", indent + 2, INDENT_STRING);
+            }
+            printf("\n%.*s]", indent, INDENT_STRING);
+            break;
+        case kJSObject:
+            printf("{\n");
+            for (int i = 0; i < value->size; i++) {
+                printf("%.*s\"%s\": ", indent + 2, INDENT_STRING, value->keys[i]);
+                __printJSON(&(value->values[i]), indent + 2);
+                if (i+1 != value->size) printf(",\n", indent +2, INDENT_STRING);
+            }
+            printf("\n%.*s}", indent, INDENT_STRING);
+            break;
+        default: break;
+    }
+
+    return 0;
+}
+int printJSON(struct JSONMsgCodecValue *value, int indent) {
+    printf("%.*s", indent, INDENT_STRING);
+    __printJSON(value, indent);
+    printf("\n");
+}
+int __printStd(struct StdMsgCodecValue *value, int indent) {
+    switch (value->type) {
+        case kNull:
+            printf("null");
+            break;
+        case kTrue:
+            printf("true");
+            break;
+        case kFalse:
+            printf("false");
+            break;
+        case kInt32:
+            printf("%" PRIi32, value->int32_value);
+            break;
+        case kInt64:
+            printf("%" PRIi64, value->int64_value);
+            break;
+        case kFloat64:
+            printf("%lf", value->float64_value);
+            break;
+        case kString:
+        case kLargeInt:
+            printf("\"%s\"", value->string_value);
+            break;
+        case kUInt8Array:
+            printf("(uint8_t) [");
+            for (int i = 0; i < value->size; i++) {
+                printf("0x%02X", value->uint8array[i]);
+                if (i + 1 != value->size) printf(", ");
+            }
+            printf("]");
+            break;
+        case kInt32Array:
+            printf("(int32_t) [");
+            for (int i = 0; i < value->size; i++) {
+                printf("%" PRIi32, value->int32array[i]);
+                if (i + 1 != value->size) printf(", ");
+            }
+            printf("]");
+            break;
+        case kInt64Array:
+            printf("(int64_t) [");
+            for (int i = 0; i < value->size; i++) {
+                printf("%" PRIi64, value->int64array[i]);
+                if (i + 1 != value->size) printf(", ");
+            }
+            printf("]");
+            break;
+        case kFloat64Array:
+            printf("(double) [");
+            for (int i = 0; i < value->size; i++) {
+                printf("%ld", value->float64array[i]);
+                if (i + 1 != value->size) printf(", ");
+            }
+            printf("]");
+            break;
+        case kList:
+            printf("[\n");
+            for (int i = 0; i < value->size; i++) {
+                printf("%.*s", indent + 2, INDENT_STRING);
+                __printStd(&(value->list[i]), indent + 2);
+                if (i + 1 != value->size) printf(",\n");
+            }
+            printf("\n%.*s]", indent, INDENT_STRING);
+            break;
+        case kMap:
+            printf("{\n");
+            for (int i = 0; i < value->size; i++) {
+                printf("%.*s", indent + 2, INDENT_STRING);
+                __printStd(&(value->keys[i]), indent + 2);
+                printf(": ");
+                __printStd(&(value->values[i]), indent + 2);
+                if (i + 1 != value->size) printf(",\n");
+            }
+            printf("\n%.*s}", indent, INDENT_STRING);
+            break;
+        default:
+            break;
+    }
+}
+int printStd(struct StdMsgCodecValue *value, int indent) {
+    printf("%.*s", indent, INDENT_STRING);
+    __printStd(value, indent);
+    printf("\n");
+}
+
+#undef INDENT_STRING
+
+
+int TestPlugin_onReceiveResponseJSON(struct ChannelObject *object, void *userdata) {
+    uint64_t dt = FlutterEngineGetCurrentTime() - *((uint64_t*) userdata);
+    free(userdata);
+
+    if (object->success) {
+        printf("TestPlugin_onReceiveResponseJSON(dt: %lluns)\n"
+               "  success\n"
+               "  result:\n", dt);
+        printJSON(&object->jsresult, 4);
+    } else {
+        printf("TestPlugin_onReceiveResponseJSON(dt: %lluns)\n", dt);
+        printf("  failure\n"
+               "  error code: %s\n"
+               "  error message: %s\n"
+               "  error details:\n", object->errorcode, (object->errormessage != NULL) ? object->errormessage : "null");
+        printJSON(&object->jsresult, 4);
+    }
+
+    return 0;
+}
+int TestPlugin_sendJSON() {
+    uint64_t* time = malloc(sizeof(uint64_t));
+    *time = FlutterEngineGetCurrentTime();
+
+    char *method = "test";
+    struct JSONMsgCodecValue argument = {
+        .type = kJSObject,
+        .size = 5,
+        .keys = (char*[]) {
+            "key1",
+            "key2",
+            "key3",
+            "key4",
+            "array"
+        },
+        .values = (struct JSONMsgCodecValue[]) {
+            {.type = kJSString, .string_value = "value1"},
+            {.type = kJSTrue},
+            {.type = kJSNumber, .number_value = -1000},
+            {.type = kJSNumber, .number_value = -5.0005},
+            {.type = kJSArray, .size = 2, .array = (struct JSONMsgCodecValue[]) {
+                {.type = kJSString, .string_value = "array1"},
+                {.type = kJSNumber, .number_value = 2}
+            }}
+        },
+    };
+
+    int ok = PlatformChannel_jsoncall(TESTPLUGIN_CHANNEL_JSON, method, &argument, TestPlugin_onReceiveResponseJSON, time);
+    if (ok != 0) {
+        printf("Could not MethodCall JSON: %s\n", strerror(ok));
+    }
+}
+int TestPlugin_onReceiveResponseStd(struct ChannelObject *object, void *userdata) {
+    uint64_t dt = FlutterEngineGetCurrentTime() - *((uint64_t*) userdata);
+    free(userdata);
+
+    if (object->success) {
+        printf("TestPlugin_onReceiveResponseStd(dt: %lluns)\n"
+               "  success\n"
+               "  result:\n", dt);
+        printStd(&object->stdresult, 4);
+    } else {
+        printf("TestPlugin_onReceiveResponseStd(dt: %lluns)\n", dt);
+        printf("  failure\n"
+               "  error code: %s\n"
+               "  error message: %s\n"
+               "  error details:\n", object->errorcode, (object->errormessage != NULL) ? object->errormessage : "null");
+        printStd(&object->stdresult, 4);
+    }
+
+    return 0;
+}
+int TestPlugin_sendStd() {
+    uint64_t *time = malloc(sizeof(uint64_t));
+    *time = FlutterEngineGetCurrentTime();
+
+    char *method = "test";
+    struct StdMsgCodecValue argument = {
+        .type = kMap,
+        .size = 7,
+        .keys = (struct StdMsgCodecValue[]) {
+            {.type = kString, .string_value = "key1"},
+            {.type = kString, .string_value = "key2"},
+            {.type = kString, .string_value = "key3"},
+            {.type = kString, .string_value = "key4"},
+            {.type = kInt32, .int32_value = 5},
+            {.type = kString, .string_value = "timestamp"},
+            {.type = kString, .string_value = "array"}
+        },
+        .values = (struct StdMsgCodecValue[]) {
+            {.type = kString, .string_value = "value1"},
+            {.type = kTrue},
+            {.type = kInt32, .int32_value = -1000},
+            {.type = kFloat64, .float64_value = -5.0005},
+            {.type = kUInt8Array, .uint8array = (uint8_t[]) {0x00, 0x01, 0x02, 0x03, 0xFF}, .size = 5},
+            {.type = kInt64, .int64_value = *time & 0x7FFFFFFFFFFFFFFF},
+            {.type = kList, .size = 2, .list = (struct StdMsgCodecValue[]) {
+                {.type = kString, .string_value = "array1"},
+                {.type = kInt32, .int32_value = 2}
+            }}
+        },
+    };
+
+    PlatformChannel_stdcall(TESTPLUGIN_CHANNEL_STD, method, &argument, TestPlugin_onReceiveResponseStd, time);
+}
+
+
+int TestPlugin_onReceiveJSON(char *channel, struct ChannelObject *object, FlutterPlatformMessageResponseHandle *responsehandle) {
+    printf("TestPlugin_onReceiveJSON(channel: %s)\n"
+           "  method: %s\n"
+           "  args: \n", channel, object->method);
+    printJSON(&(object->jsarg), 4);
+    
+    TestPlugin_sendJSON();
+
+    return PlatformChannel_respond(responsehandle, &(struct ChannelObject) {
+        .codec = kJSONMethodCallResponse,
+        .success = true,
+        .jsresult = {
+            .type = kJSTrue
+        }
+    });
+}
+int TestPlugin_onReceiveStd(char *channel, struct ChannelObject *object, FlutterPlatformMessageResponseHandle *responsehandle) {
+    printf("TestPlugin_onReceiveStd(channel: %s)\n"
+           "  method: %s\n"
+           "  args: \n", channel, object->method);
+
+    printStd(&(object->stdarg), 4);
+
+    TestPlugin_sendStd();
+    
+    return PlatformChannel_respond(
+        responsehandle,
+        &(struct ChannelObject) {
+            .codec = kStandardMethodCallResponse,
+            .success = true,
+            .stdresult = {
+                .type = kTrue
+            }
+        }
+    );
+}
+
+
+int TestPlugin_init(void) {
+    printf("Initializing Testplugin\n");
+    PluginRegistry_setReceiver(TESTPLUGIN_CHANNEL_JSON, kJSONMethodCall, TestPlugin_onReceiveJSON);
+    PluginRegistry_setReceiver(TESTPLUGIN_CHANNEL_STD, kStandardMethodCall, TestPlugin_onReceiveStd);
+    return 0;
+}
+int TestPlugin_deinit(void) {
+    printf("Deinitializing Testplugin\n");
+    return 0;
+}

--- a/src/testplugin.h
+++ b/src/testplugin.h
@@ -1,0 +1,10 @@
+#ifndef _TEST_PLUGIN_H
+#define _TEST_PLUGIN_H
+
+#include <stdio.h>
+#include <string.h>
+
+extern int TestPlugin_init(void);
+extern int TestPlugin_deinit(void);
+
+#endif


### PR DESCRIPTION
- plugin registry featuring hardcoded plugins
- platform channels now support all of the following: String-, Binary-, StandardMessage-, StandardMethod-, JSONMessage- & JSONMethod-codec, including StandardMethodCodec & JSONMethodCodec responses and sending and receiving "not implemented" messages.
- testplugin for testing the functionality of StandardMethod- & JSONMethodCodec.
- helper functions for handling StdMsgCodec- & JSONMsgCodecValues
- ServicesPlugin for handling some service messages, but this is just a stub right now.