### PR TITLE
Convert tabs to spaces.

### DIFF
--- a/src/flutter-pi.c
+++ b/src/flutter-pi.c
@@ -80,8 +80,8 @@ OPTIONS:\n\
   --release                  Run the app in release mode. The AOT snapshot\n\
                              of the app (\"app.so\") must be located inside the\n\
                              asset bundle directory.\n\
-							 This also requires a libflutter_engine.so that was\n\
-							 built with --runtime-mode=release.\n\
+                             This also requires a libflutter_engine.so that was\n\
+                             built with --runtime-mode=release.\n\
                              \n\
   -o, --orientation <orientation>  Start the app in this orientation. Valid\n\
                              for <orientation> are: portrait_up, landscape_left,\n\


### PR DESCRIPTION
There's a bunch of places where tabs are used instead of spaces. I've no idea if it's intentional, but I noticed that in the help screen, it causes one paragraph to be overly indented on systems that use tab stops at 8 characters instead of 4, so I'm guessing it's not intentional.

This just replaces all tabs with four spaces uniformly.

Let me know if the better fix is just to change the help string but leave the others.