### PR TITLE
Correct locale extraction to exclude delims

### DIFF
--- a/include/locales.h
+++ b/include/locales.h
@@ -34,4 +34,6 @@ int locales_add_to_fl_engine(struct locales *locales, FlutterEngine engine, Flut
 
 const FlutterLocale *locales_on_compute_platform_resolved_locale(struct locales *locales, const FlutterLocale **fl_locales, size_t n_fl_locales);
 
+void locales_print(const struct locales *locales);
+
 #endif

--- a/src/flutter-pi.c
+++ b/src/flutter-pi.c
@@ -170,7 +170,7 @@ static bool on_make_current(void* userdata) {
         LOG_ERROR("Could not make the flutter rendering EGL context current. eglMakeCurrent: 0x%08X\n", egl_error);
         return false;
     }
-    
+
     return true;
 }
 
@@ -188,7 +188,7 @@ static bool on_clear_current(void* userdata) {
         LOG_ERROR("Could not clear the flutter EGL context. eglMakeCurrent: 0x%08X\n", egl_error);
         return false;
     }
-    
+
     return true;
 }
 
@@ -224,7 +224,7 @@ static bool on_make_resource_current(void *userdata) {
         LOG_ERROR("Could not make the flutter resource uploading EGL context current. eglMakeCurrent: 0x%08X\n", egl_error);
         return false;
     }
-    
+
     return true;
 }
 
@@ -260,7 +260,7 @@ static const GLubyte *hacked_glGetString(GLenum name) {
 
     if (extensions == NULL) {
         GLubyte *orig_extensions = (GLubyte *) glGetString(GL_EXTENSIONS);
-        
+
         extensions = malloc(strlen((const char*)orig_extensions) + 1);
         if (!extensions) {
             return NULL;
@@ -334,7 +334,7 @@ static const GLubyte *hacked_glGetString(GLenum name) {
     return extensions;
 }
 
-/// Called by flutter 
+/// Called by flutter
 static void *proc_resolver(
     void* userdata,
     const char* name
@@ -344,7 +344,7 @@ static void *proc_resolver(
 
     (void) userdata;
 
-    /*  
+    /*
      * The mesa V3D driver reports some OpenGL ES extensions as supported and working
      * even though they aren't. hacked_glGetString is a workaround for this, which will
      * cut out the non-working extensions from the list of supported extensions.
@@ -366,7 +366,7 @@ static void *proc_resolver(
 
     if ((address = dlsym(RTLD_DEFAULT, name)) || (address = eglGetProcAddress(name)))
         return address;
-    
+
     LOG_ERROR("proc_resolver: Could not resolve symbol \"%s\"\n", name);
 
     return NULL;
@@ -414,7 +414,7 @@ static int on_execute_frame_request(
             } else {
                 ns = flutterpi.flutter.libflutter_engine.FlutterEngineGetCurrentTime();
             }
-            
+
             result = flutterpi.flutter.libflutter_engine.FlutterEngineOnVsync(
                 flutterpi.flutter.engine,
                 peek->baton,
@@ -430,7 +430,7 @@ static int on_execute_frame_request(
             peek->state = kFrameRendering;
         }
     } else if (ok == EAGAIN) {
-        // do nothing	
+        // do nothing
     } else if (ok != 0) {
         LOG_ERROR("Could not get peek of frame queue. cqueue_peek_locked: %s\n", strerror(ok));
         cqueue_unlock(&flutterpi.frame_queue);
@@ -610,7 +610,7 @@ int flutterpi_post_platform_task_with_time(
 
     task->callback = callback;
     task->userdata = userdata;
-    
+
     if (pthread_self() != flutterpi.event_loop_thread) {
         pthread_mutex_lock(&flutterpi.event_loop_mutex);
     }
@@ -738,7 +738,7 @@ static void on_post_flutter_task(
     if (dup_task == NULL) {
         return;
     }
-    
+
     *dup_task = task;
 
     ok = flutterpi_post_platform_task_with_time(
@@ -801,7 +801,7 @@ int flutterpi_send_platform_message(
     struct platform_message *msg;
     FlutterEngineResult result;
     int ok;
-    
+
     if (runs_platform_tasks_on_current_thread(NULL)) {
         result = flutterpi.flutter.libflutter_engine.FlutterEngineSendPlatformMessage(
             flutterpi.flutter.engine,
@@ -831,7 +831,7 @@ int flutterpi_send_platform_message(
         }
 
         msg->response_handle = responsehandle;
-        
+
         if (message && message_size) {
             msg->message_size = message_size;
             msg->message = memdup(message, message_size);
@@ -870,7 +870,7 @@ int flutterpi_respond_to_platform_message(
     struct platform_message *msg;
     FlutterEngineResult result;
     int ok;
-    
+
     if (runs_platform_tasks_on_current_thread(NULL)) {
         result = flutterpi.flutter.libflutter_engine.FlutterEngineSendPlatformMessageResponse(
             flutterpi.flutter.engine,
@@ -944,13 +944,13 @@ EGLDisplay flutterpi_get_egl_display(struct flutterpi *flutterpi) {
 
 EGLContext flutterpi_create_egl_context(struct flutterpi *flutterpi) {
     EGLContext context;
-    
+
     pthread_mutex_lock(&flutterpi->egl.temp_context_lock);
 
     context = eglCreateContext(
-        flutterpi->egl.display, 
-        flutterpi->egl.config, 
-        flutterpi->egl.temp_context, 
+        flutterpi->egl.display,
+        flutterpi->egl.config,
+        flutterpi->egl.temp_context,
         (EGLint[]) {
             EGL_CONTEXT_CLIENT_VERSION, 2,
             EGL_NONE
@@ -1014,7 +1014,7 @@ static int run_main_loop(void) {
         const fd_set const_fds = rfds;
 
         pthread_mutex_lock(&flutterpi.event_loop_mutex);
-         
+
         do {
             state = sd_event_get_state(flutterpi.event_loop);
             switch (state) {
@@ -1041,7 +1041,7 @@ static int run_main_loop(void) {
                     } while ((ok < 0) && (errno == EINTR));
 
                     pthread_mutex_lock(&flutterpi.event_loop_mutex);
-                        
+
                     ok = sd_event_wait(flutterpi.event_loop, 0);
                     if (ok < 0) {
                         LOG_ERROR("Could not check for event loop events. sd_event_wait: %s\n", strerror(-ok));
@@ -1150,7 +1150,7 @@ void on_pageflip_event(
     flutterpi.flutter.libflutter_engine.FlutterEngineTraceEventInstant("pageflip");
 
     cqueue_lock(&flutterpi.frame_queue);
-    
+
     ok = cqueue_try_dequeue_locked(&flutterpi.frame_queue, &presented_frame);
     if (ok != 0) {
         LOG_ERROR("Could not dequeue completed frame from frame queue: %s\n", strerror(ok));
@@ -1249,7 +1249,7 @@ int flutterpi_fill_view_properties(
         if (flutterpi.view.rotation >= 360) {
             flutterpi.view.rotation -= 360;
         }
-        
+
         flutterpi.view.orientation = orientation;
     } else if (has_rotation) {
         for (int i = kPortraitUp; i <= kLandscapeRight; i++) {
@@ -1365,18 +1365,18 @@ static int init_display(void) {
     /**********************
      * DRM INITIALIZATION *
      **********************/
-    
+
     num_devices = drmGetDevices2(0, devices, sizeof(devices)/sizeof(*devices));
     if (num_devices < 0) {
         LOG_ERROR("Could not query DRM device list: %s\n", strerror(-num_devices));
         return -num_devices;
     }
-    
+
     // find a GPU that has a primary node
     flutterpi.drm.drmdev = NULL;
     for (int i = 0; i < num_devices; i++) {
         drmDevicePtr device;
-        
+
         device = devices[i];
 
         if (!(device->available_nodes & (1 << DRM_NODE_PRIMARY))) {
@@ -1468,7 +1468,7 @@ static int init_display(void) {
         flutterpi.display.pixel_ratio = 1.0;
     } else {
         flutterpi.display.pixel_ratio = (10.0 * flutterpi.display.width) / (flutterpi.display.width_mm * 38.0);
-        
+
         int horizontal_dpi = (int) (flutterpi.display.width / (flutterpi.display.width_mm / 25.4));
         int vertical_dpi = (int) (flutterpi.display.height / (flutterpi.display.height_mm / 25.4));
 
@@ -1477,13 +1477,13 @@ static int init_display(void) {
             LOG_ERROR("WARNING: display has non-square pixels. Non-square-pixels are not supported by flutter.\n");
         }
     }
-    
+
     for_each_encoder_in_drmdev(flutterpi.drm.drmdev, encoder) {
         if (encoder->encoder->encoder_id == connector->connector->encoder_id) {
             break;
         }
     }
-    
+
     if (encoder == NULL) {
         for (int i = 0; i < connector->connector->count_encoders; i++, encoder = NULL) {
             for_each_encoder_in_drmdev(flutterpi.drm.drmdev, encoder) {
@@ -1563,6 +1563,7 @@ static int init_display(void) {
         return -ok;
     }
 
+    locales_print(flutterpi.locales);
     printf(
         "===================================\n"
         "display mode:\n"
@@ -1633,7 +1634,7 @@ static int init_display(void) {
         return EIO;
     }
 #endif
-    
+
     eglInitialize(flutterpi.egl.display, &major, &minor);
     if ((egl_error = eglGetError()) != EGL_SUCCESS) {
         LOG_ERROR("Failed to initialize EGL! eglInitialize: 0x%08X\n", egl_error);
@@ -1658,7 +1659,7 @@ static int init_display(void) {
     EGLint count = 0, matched = 0;
     EGLConfig *configs;
     bool _found_matching_config = false;
-    
+
     eglGetConfigs(flutterpi.egl.display, NULL, 0, &count);
     if ((egl_error = eglGetError()) != EGL_SUCCESS) {
         LOG_ERROR("Could not get the number of EGL framebuffer configurations. eglGetConfigs: 0x%08X\n", egl_error);
@@ -1999,7 +2000,7 @@ static int init_application(void) {
         LOG_ERROR("Could not initialize the flutter engine. FlutterEngineInitialize: %s\n", FLUTTER_RESULT_TO_STRING(engine_result));
         return EINVAL;
     }
-    
+
     engine_result = libflutter_engine->FlutterEngineRunInitialized(flutterpi.flutter.engine);
     if (engine_result != kSuccess) {
         LOG_ERROR("Could not run the flutter engine. FlutterEngineRunInitialized: %s\n", FLUTTER_RESULT_TO_STRING(engine_result));
@@ -2067,7 +2068,7 @@ int flutterpi_schedule_exit(void) {
     if (pthread_self() != flutterpi.event_loop_thread) {
         pthread_mutex_lock(&flutterpi.event_loop_mutex);
     }
-    
+
     ok = sd_event_exit(flutterpi.event_loop, 0);
     if (ok < 0) {
         LOG_ERROR("Could not schedule application exit. sd_event_exit: %s\n", strerror(-ok));
@@ -2207,7 +2208,7 @@ static const struct user_input_interface user_input_interface = {
 
 static int on_user_input_fd_ready(sd_event_source *s, int fd, uint32_t revents, void *userdata) {
     struct user_input *input;
-    
+
     (void) s;
     (void) fd;
     (void) revents;
@@ -2221,9 +2222,9 @@ static int init_user_input(void) {
     struct user_input *input;
     sd_event_source *event_source;
     int ok;
-    
+
     event_source = NULL;
-    
+
     input = user_input_new(
         &user_input_interface,
         &flutterpi,
@@ -2249,7 +2250,7 @@ static int init_user_input(void) {
             input = NULL;
         }
     }
-    
+
     flutterpi.user_input = input;
     flutterpi.user_input_event_source = event_source;
 
@@ -2265,7 +2266,7 @@ static bool setup_paths(void) {
         LOG_ERROR("Asset Bundle Directory \"%s\" does not exist\n", flutterpi.flutter.asset_bundle_path);
         return false;
     }
-    
+
     asprintf(&kernel_blob_path, "%s/kernel_blob.bin", flutterpi.flutter.asset_bundle_path);
     asprintf(&app_elf_path, "%s/app.so", flutterpi.flutter.asset_bundle_path);
 
@@ -2340,13 +2341,13 @@ static bool parse_cmd_args(int argc, char **argv) {
                     LOG_ERROR(
                         "ERROR: Invalid argument for --orientation passed.\n"
                         "Valid values are \"portrait_up\", \"landscape_left\", \"portrait_down\", \"landscape_right\".\n"
-                        "%s", 
+                        "%s",
                         usage
                     );
                     return false;
                 }
                 break;
-            
+
             case 'r':
                 errno = 0;
                 long rotation = strtol(optarg, NULL, 0);
@@ -2363,7 +2364,7 @@ static bool parse_cmd_args(int argc, char **argv) {
                 flutterpi.view.rotation = rotation;
                 flutterpi.view.has_rotation = true;
                 break;
-            
+
             case 'd': ;
                 unsigned int width_mm, height_mm;
 
@@ -2375,9 +2376,9 @@ static bool parse_cmd_args(int argc, char **argv) {
 
                 flutterpi.display.width_mm = width_mm;
                 flutterpi.display.height_mm = height_mm;
-                
+
                 break;
-            
+
             case 'p':
                 for (int i = 0; i < n_pixfmt_infos; i++) {
                     if (strcmp(optarg, pixfmt_infos[i].arg_name) == 0) {
@@ -2389,7 +2390,7 @@ static bool parse_cmd_args(int argc, char **argv) {
                 LOG_ERROR(
                     "ERROR: Invalid argument for --pixelformat passed.\n"
                     "Valid values are: RGB565, ARGB8888, XRGB8888, BGRA8888, RGBA8888\n"
-                    "%s", 
+                    "%s",
                     usage
                 );
 
@@ -2399,7 +2400,7 @@ static bool parse_cmd_args(int argc, char **argv) {
 
                 valid_format:
                 break;
-            
+
             case 'h':
                 printf("%s", usage);
                 return false;
@@ -2408,16 +2409,16 @@ static bool parse_cmd_args(int argc, char **argv) {
             case ':':
                 LOG_ERROR("Invalid option specified.\n%s", usage);
                 return false;
-            
+
             case -1:
                 finished_parsing_options = true;
                 break;
-            
+
             default:
                 break;
         }
     }
-    
+
 
     if (optind >= argc) {
         LOG_ERROR("ERROR: Expected asset bundle path after options.\n");

--- a/src/locales.c
+++ b/src/locales.c
@@ -25,7 +25,7 @@ struct locales {
 
     struct concurrent_pointer_set locales;
     struct locale *default_locale;
-    
+
     size_t n_locales;
 };
 
@@ -169,7 +169,8 @@ static int add_locale_variants(struct concurrent_pointer_set *locales, const cha
     at = strchr(dot ? dot : (underscore ? underscore : locale_description), '@');
 
     if (at != NULL) {
-        modifier = strdup(at);
+        //exclude @
+        modifier = strdup(at + 1);
         if (modifier == NULL) {
             ok = ENOMEM;
             goto fail_return_ok;
@@ -179,7 +180,8 @@ static int add_locale_variants(struct concurrent_pointer_set *locales, const cha
     }
 
     if (dot != NULL) {
-        codeset = strndup(dot, next_delim - dot);
+        //exclude . and @
+        codeset = strndup(dot + 1, next_delim - dot - 1);
         if (codeset == NULL) {
             ok = ENOMEM;
             goto fail_free_modifier;
@@ -188,7 +190,8 @@ static int add_locale_variants(struct concurrent_pointer_set *locales, const cha
     }
 
     if (underscore != NULL) {
-        territory = strndup(underscore, next_delim - underscore);
+        //exclude _ and .
+        territory = strndup(underscore + 1, next_delim - underscore - 1);
         if (territory == NULL) {
             ok = ENOMEM;
             goto fail_free_codeset;
@@ -196,6 +199,7 @@ static int add_locale_variants(struct concurrent_pointer_set *locales, const cha
         next_delim = underscore;
     }
 
+    //nothing to exclude
     language = strndup(locale_description, next_delim - locale_description);
     if (language == NULL) {
         ok = ENOMEM;
@@ -254,7 +258,7 @@ static int add_locale_variants(struct concurrent_pointer_set *locales, const cha
     if (modifier) free(modifier);
 
     fail_return_ok:
-    return ok;   
+    return ok;
 }
 
 struct locales *locales_new(void) {
@@ -275,7 +279,7 @@ struct locales *locales_new(void) {
     if (ok != 0) {
         goto fail_free_locales;
     }
-    
+
     // Add our system locales.
     system_locales = get_system_locale_string();
 
@@ -378,7 +382,7 @@ const char *locale_get_modifier(struct locale *locale) {
 
 int locales_add_to_fl_engine(struct locales *locales, FlutterEngine engine, FlutterEngineUpdateLocalesFnPtr update_locales) {
     FlutterEngineResult engine_result;
-    
+
     engine_result = update_locales(engine, locales->flutter_locales, locales->n_locales);
     if (engine_result != kSuccess) {
         LOG_LOCALES_ERROR("Couldn't update flutter engine locales. FlutterEngineUpdateLocales: %s\n", FLUTTER_RESULT_TO_STRING(engine_result));
@@ -395,6 +399,46 @@ const FlutterLocale *locales_on_compute_platform_resolved_locale(struct locales 
 
     (void) locales;
     (void) n_fl_locales;
-    
+
     return fl_locales[0];
+}
+
+void locales_print(const struct locales *locales) {
+    DEBUG_ASSERT(locales != NULL);
+
+    printf("==============Locale==============\n");
+    printf("Flutter locale:\n");
+    if (locales->default_flutter_locale != NULL) {
+        printf("  default: %s", locales->default_flutter_locale->language_code);
+        if (locales->default_flutter_locale->country_code != NULL) {
+            printf("_%s", locales->default_flutter_locale->country_code);
+        }
+        if (locales->default_flutter_locale->script_code != NULL) {
+            printf(".%s", locales->default_flutter_locale->script_code);
+        }
+        if (locales->default_flutter_locale->variant_code != NULL) {
+            printf("@%s", locales->default_flutter_locale->variant_code);
+        }
+
+        printf("\n");
+    } else {
+        printf("  default: NULL\n");
+    }
+
+    printf("  locales:");
+    for (size_t idx = 0; idx < locales->n_locales; idx++) {
+        const FlutterLocale *locale = locales->flutter_locales[idx];
+        printf(" %s", locale->language_code);
+        if (locale->country_code != NULL) {
+            printf("_%s", locale->country_code);
+        }
+        if (locale->script_code != NULL) {
+            printf(".%s", locale->script_code);
+        }
+        if (locale->variant_code != NULL) {
+            printf("@%s", locale->variant_code);
+        }
+    }
+
+    printf("\n===================================\n");
 }


### PR DESCRIPTION
Subj 
This PR corrects extraction of locale information 
Originally code would include delimiter inside country code, encoding or modifier. 
This PR intentionally excludes these delimiters now, making flutter-pi to initialize flutter locale information without them correctly  
I also added printing of locale during startup, it would be helpful to identify it for user instead of debugging :)

P.s. This only affects applications that rely on system locale information (e.g. easy_localization which uses system locale as default)