### PR TITLE
Flush terminal output when terminating.

### DIFF
--- a/src/flutter-pi.c
+++ b/src/flutter-pi.c
@@ -56,6 +56,7 @@
 #include <plugins/text_input.h>
 #include <plugins/raw_keyboard.h>
 
+#include <termios.h>
 #ifdef ENABLE_MTRACE
 #   include <mcheck.h>
 #endif
@@ -2510,5 +2511,6 @@ int main(int argc, char **argv) {
 
     deinit();
 
+    tcflush(STDIN_FILENO, TCIOFLUSH);
     return EXIT_SUCCESS;
 }


### PR DESCRIPTION
Keyboard input reaches the terminal after the program terminates. 
It's possible to type entire commands that get executed once the app quits.

This PR discards the contents of `stdin` when the app terminates.
There may be cases (crashes?) where this is not enough, but fixes the most common cases (`Ctrl-c` and flutter app termination via `dart:io:exit()`).