### PR TITLE
Fix unicode symbol length calculation.

### DIFF
--- a/src/plugins/text_input.c
+++ b/src/plugins/text_input.c
@@ -32,20 +32,21 @@ struct text_input {
  * UTF8 utility functions
  */
 static inline uint8_t utf8_symbol_length(uint8_t c) {
-    if (!(c & 0b10000000)) {
-        return 1;
-    } else if (!(c & 0b01000000)) {
-        // we are in a follow byte
-        return 0;
-    } else if (c & 0b00100000) {
-        return 2;
-    } else if (c & 0b00010000) {
-        return 3;
-    } else if (c & 0b00001000) {
+    if ((c & 0b11110000) == 0b11110000) {
         return 4;
     }
-
-    return 0;
+    if ((c & 0b11100000) == 0b11100000) {
+        return 3;
+    }
+    if ((c & 0b11000000) == 0b11000000) {
+        return 2;
+    }
+    if ((c & 0b10000000) == 0b10000000) {
+        // XXX should we return 1 and don't care here?
+        fprintf(stderr, "weird char start: %x\n", c);
+        return 0;
+    }
+    return 1;
 }
 
 static inline uint8_t *symbol_at(unsigned int symbol_index) {


### PR DESCRIPTION
Symbol length calculation was wrong and inputting non ascii symbols resulted in nothing inserted in the textfield (ex. accented characters, euro symbol, yen symbol).

