### PR TITLE
Do not filter text field input based on selected keyboard type.

### DIFF
--- a/src/plugins/text_input.c
+++ b/src/plugins/text_input.c
@@ -875,23 +875,6 @@ static int sync_editing_state(void) {
 int textin_on_utf8_char(uint8_t *c) {
     if (text_input.connection_id == -1)
         return 0;
-    
-    switch (text_input.input_type) {
-        case kInputTypeNumber:
-            if (isdigit(*c)) {
-                break;
-            } else {
-                return 0;
-            }
-        case kInputTypePhone:
-            if (isdigit(*c) || *c == '*' || *c == '#' || *c == '+') {
-                break;
-            } else {
-                return 0;
-            }
-        default:
-            break;
-    }
 
     if (model_add_utf8_char(c))
         return sync_editing_state();


### PR DESCRIPTION
On standard flutter, no input filtering is done based on the
keyboardType parameter of the TextField constructor.
Input filtering should be done via the inputFormatters parameter of the
TextField constructor. See https://api.flutter.dev/flutter/services/TextInputFormatter-class.html