### PR TITLE
Fallback to gbm_surface_create if gbm_surface_create_with_modifiers does not work

### DIFF
--- a/src/flutter-pi.c
+++ b/src/flutter-pi.c
@@ -1594,8 +1594,14 @@ static int init_display(void) {
 
     flutterpi.gbm.surface = gbm_surface_create_with_modifiers(flutterpi.gbm.device, flutterpi.display.width, flutterpi.display.height, flutterpi.gbm.format, &flutterpi.gbm.modifier, 1);
     if (flutterpi.gbm.surface == NULL) {
-        perror("[flutter-pi] Could not create GBM Surface. gbm_surface_create_with_modifiers");
-        return errno;
+        perror("[flutter-pi] Could not create GBM Surface. gbm_surface_create_with_modifiers. Will attempt with gbm_surface_create");
+		
+		flutterpi.gbm.surface = gbm_surface_create(flutterpi.gbm.device, flutterpi.display.width, flutterpi.display.height, flutterpi.gbm.format, 0);
+		
+		if (flutterpi.gbm.surface == NULL) {
+			perror("[flutter-pi] Could not create GBM Surface even with gbm_surface_create");
+			return errno;
+		}
     }
 
     /**********************

--- a/src/flutter-pi.c
+++ b/src/flutter-pi.c
@@ -1588,7 +1588,7 @@ static int init_display(void) {
      * GBM INITIALIZATION *
      **********************/
     flutterpi.gbm.device = gbm_create_device(flutterpi.drm.drmdev->fd);
-    flutterpi.gbm.format = DRM_FORMAT_ARGB8888;
+    flutterpi.gbm.format = DRM_FORMAT_RGB565;
     flutterpi.gbm.surface = NULL;
     flutterpi.gbm.modifier = DRM_FORMAT_MOD_LINEAR;
 

--- a/src/flutter-pi.c
+++ b/src/flutter-pi.c
@@ -1588,7 +1588,7 @@ static int init_display(void) {
      * GBM INITIALIZATION *
      **********************/
     flutterpi.gbm.device = gbm_create_device(flutterpi.drm.drmdev->fd);
-    flutterpi.gbm.format = DRM_FORMAT_RGB565;
+    flutterpi.gbm.format = DRM_FORMAT_ARGB8888;
     flutterpi.gbm.surface = NULL;
     flutterpi.gbm.modifier = DRM_FORMAT_MOD_LINEAR;
 

--- a/src/flutter-pi.c
+++ b/src/flutter-pi.c
@@ -1596,7 +1596,7 @@ static int init_display(void) {
     if (flutterpi.gbm.surface == NULL) {
         perror("[flutter-pi] Could not create GBM Surface. gbm_surface_create_with_modifiers. Will attempt with gbm_surface_create");
 		
-		flutterpi.gbm.surface = gbm_surface_create(flutterpi.gbm.device, flutterpi.display.width, flutterpi.display.height, flutterpi.gbm.format, 0);
+		flutterpi.gbm.surface = gbm_surface_create(flutterpi.gbm.device, flutterpi.display.width, flutterpi.display.height, flutterpi.gbm.format, GBM_BO_USE_SCANOUT | GBM_BO_USE_RENDERING | GBM_BO_USE_LINEAR);
 		
 		if (flutterpi.gbm.surface == NULL) {
 			perror("[flutter-pi] Could not create GBM Surface even with gbm_surface_create");


### PR DESCRIPTION
Fix for issue [269](https://github.com/ardera/flutter-pi/issues/269).

gbm_surface_create_with_modifiers is not available for Mali drivers (RockPi 4 RK3399)