### PR TITLE
meta-flutter filesystem layout

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,11 @@ option(ENABLE_TSAN "True to build & link with -fsanitize=thread" OFF)
 option(ENABLE_ASAN "True to build & link with -fsanitize=address" OFF)
 option(ENABLE_UBSAN "True to build & link with -fsanitize=undefined" OFF)
 option(ENABLE_MTRACE "True if flutter-pi should call GNU mtrace() on startup." OFF)
+
+set(FILESYSTEM_LAYOUTS default meta-flutter-dunfell meta-flutter-kirkstone)
+set(FILESYSTEM_LAYOUT "default" CACHE STRING "Where to look for the icudtl.dat, app.so/libapp.so, flutter asset bundle.")
+set_property(CACHE FILESYSTEM_LAYOUT PROPERTY STRINGS ${FILESYSTEM_LAYOUTS})
+
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 if(NOT FLUTTER_EMBEDDER_HEADER)
@@ -124,6 +129,7 @@ add_executable(flutter-pi
   src/locales.c
   src/notifier_listener.c
   src/pixel_format.c
+  src/filesystem_layout.c
   src/plugins/services.c
 )
 
@@ -170,6 +176,20 @@ target_compile_options(flutter-pi PRIVATE
 
 # TODO: Just unconditionally define those, make them optional later
 target_compile_definitions(flutter-pi PRIVATE HAS_KMS HAS_EGL HAS_GBM HAS_FBDEV)
+
+if(NOT FILESYSTEM_LAYOUT IN_LIST FILESYSTEM_LAYOUTS)
+  message(FATAL_ERROR "FILESYSTEM_LAYOUT must be one of ${FILESYSTEM_LAYOUTS}")
+endif()
+
+message(STATUS "Filesystem Layout ...... ${FILESYSTEM_LAYOUT}")
+
+if(FILESYSTEM_LAYOUT STREQUAL default)
+  target_compile_definitions(flutter-pi PRIVATE "FILESYSTEM_LAYOUT_DEFAULT")
+elseif(FILESYSTEM_LAYOUT STREQUAL meta-flutter-dunfell)
+  target_compile_definitions(flutter-pi PRIVATE "FILESYSTEM_LAYOUT_DUNFELL")
+elseif(FILESYSTEM_LAYOUT STREQUAL meta-flutter-kirkstone)
+  target_compile_definitions(flutter-pi PRIVATE "FILESYSTEM_LAYOUT_KIRKSTONE")
+endif()
 
 # TODO: We actually don't need the compile definitions anymore, except for
 # text input and raw keyboard plugin (because those have special treatment

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,7 @@ option(ENABLE_ASAN "True to build & link with -fsanitize=address" OFF)
 option(ENABLE_UBSAN "True to build & link with -fsanitize=undefined" OFF)
 option(ENABLE_MTRACE "True if flutter-pi should call GNU mtrace() on startup." OFF)
 
-set(FILESYSTEM_LAYOUTS default meta-flutter-dunfell meta-flutter-kirkstone)
+set(FILESYSTEM_LAYOUTS default meta-flutter)
 set(FILESYSTEM_LAYOUT "default" CACHE STRING "Where to look for the icudtl.dat, app.so/libapp.so, flutter asset bundle.")
 set_property(CACHE FILESYSTEM_LAYOUT PROPERTY STRINGS ${FILESYSTEM_LAYOUTS})
 
@@ -185,10 +185,8 @@ message(STATUS "Filesystem Layout ...... ${FILESYSTEM_LAYOUT}")
 
 if(FILESYSTEM_LAYOUT STREQUAL default)
   target_compile_definitions(flutter-pi PRIVATE "FILESYSTEM_LAYOUT_DEFAULT")
-elseif(FILESYSTEM_LAYOUT STREQUAL meta-flutter-dunfell)
-  target_compile_definitions(flutter-pi PRIVATE "FILESYSTEM_LAYOUT_DUNFELL")
-elseif(FILESYSTEM_LAYOUT STREQUAL meta-flutter-kirkstone)
-  target_compile_definitions(flutter-pi PRIVATE "FILESYSTEM_LAYOUT_KIRKSTONE")
+elseif(FILESYSTEM_LAYOUT STREQUAL meta-flutter)
+  target_compile_definitions(flutter-pi PRIVATE "FILESYSTEM_LAYOUT_METAFLUTTER")
 endif()
 
 # TODO: We actually don't need the compile definitions anymore, except for

--- a/include/filesystem_layout.h
+++ b/include/filesystem_layout.h
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: MIT
+/*
+ * Filesystem Layout
+ *
+ * - implements different filesystem layouts for flutter artifacts
+ *
+ * Copyright (c) 2022, Hannes Winkler <hanneswinkler2000@web.de>
+ */
+
+
+#ifndef _FLUTTERPI_INCLUDE_FILESYSTEM_LAYOUT_H
+#define _FLUTTERPI_INCLUDE_FILESYSTEM_LAYOUT_H
+
+#include <flutter-pi.h>
+
+typedef struct flutter_paths *(*resolve_paths_t)(const char *app_bundle_path, enum flutter_runtime_mode runtime_mode);
+
+struct flutter_paths *fs_layout_flutterpi_resolve(const char *app_bundle_path, enum flutter_runtime_mode runtime_mode);
+struct flutter_paths *fs_layout_dunfell_resolve(const char *app_bundle_path, enum flutter_runtime_mode runtime_mode);
+struct flutter_paths *fs_layout_kirkstone_resolve(const char *app_bundle_path, enum flutter_runtime_mode runtime_mode);
+
+#endif // _FLUTTERPI_INCLUDE_FILESYSTEM_LAYOUT_H

--- a/include/filesystem_layout.h
+++ b/include/filesystem_layout.h
@@ -16,7 +16,6 @@
 typedef struct flutter_paths *(*resolve_paths_t)(const char *app_bundle_path, enum flutter_runtime_mode runtime_mode);
 
 struct flutter_paths *fs_layout_flutterpi_resolve(const char *app_bundle_path, enum flutter_runtime_mode runtime_mode);
-struct flutter_paths *fs_layout_dunfell_resolve(const char *app_bundle_path, enum flutter_runtime_mode runtime_mode);
-struct flutter_paths *fs_layout_kirkstone_resolve(const char *app_bundle_path, enum flutter_runtime_mode runtime_mode);
+struct flutter_paths *fs_layout_metaflutter_resolve(const char *app_bundle_path, enum flutter_runtime_mode runtime_mode);
 
 #endif // _FLUTTERPI_INCLUDE_FILESYSTEM_LAYOUT_H

--- a/include/flutter-pi.h
+++ b/include/flutter-pi.h
@@ -218,8 +218,22 @@ enum flutter_runtime_mode {
 	kDebug, kProfile, kRelease
 };
 
+#define FLUTTER_RUNTIME_MODE_IS_JIT(runtime_mode) ((runtime_mode) == kDebug)
+#define FLUTTER_RUNTIME_MODE_IS_AOT(runtime_mode) ((runtime_mode) == kProfile || (runtime_mode) == kRelease)
+
 struct plugin_registry;
 struct texture_registry;
+
+struct flutter_paths {
+	char *app_bundle_path;
+	char *asset_bundle_path;
+	char *app_elf_path;
+	char *icudtl_path;
+	char *kernel_blob_path;
+	char *flutter_engine_path;
+	char *flutter_engine_dlopen_name;
+	char *flutter_engine_dlopen_name_fallback;
+};
 
 struct flutterpi {
 	/// graphics stuff
@@ -336,11 +350,9 @@ struct flutterpi {
 	
 	/// flutter stuff
 	struct {
-		char *asset_bundle_path;
-		char *kernel_blob_path;
-		char *app_elf_path;
+		char *bundle_path;
+		struct flutter_paths *paths;
 		void *app_elf_handle;
-		char *icu_data_path;
 
 		FlutterLocale **locales;
 		size_t n_locales;

--- a/src/filesystem_layout.c
+++ b/src/filesystem_layout.c
@@ -1,0 +1,288 @@
+// SPDX-License-Identifier: MIT
+/*
+ * Filesystem Layout
+ *
+ * - implements different filesystem layouts for flutter artifacts
+ *   (libflutter_engine, icudtl, asset bundle, etc)
+ *
+ * Copyright (c) 2022, Hannes Winkler <hanneswinkler2000@web.de>
+ */
+
+#define _GNU_SOURCE
+#include <stdlib.h>
+#include <unistd.h>
+#include <fcntl.h>
+
+#include <collection.h>
+#include <flutter-pi.h>
+
+FILE_DESCR("fs layout")
+
+static bool path_exists(const char *path) {
+    return access(path, R_OK) == 0;
+}
+
+static struct flutter_paths *resolve(
+    const char *app_bundle_path,
+    enum flutter_runtime_mode runtime_mode,
+    const char *asset_bundle_subpath,
+    const char *icudtl_subpath,
+    const char *icudtl_system_path,
+    const char *icudtl_system_path_fallback,
+    const char *kernel_blob_subpath,
+    const char *app_elf_subpath,
+    const char *app_engine_subpath,
+    const char *engine_dlopen_name,
+    const char *engine_dlopen_name_fallback
+) {
+    struct flutter_paths *paths;
+    char *dlopen_name_fallback_duped;
+    char *app_bundle_path_real;
+    char *dlopen_name_duped;
+    char *asset_bundle_path;
+    char *kernel_blob_path;
+    char *app_elf_path;
+    char *icudtl_path;
+    char *engine_path;
+    int ok;
+
+    DEBUG_ASSERT_NOT_NULL(app_bundle_path);
+    DEBUG_ASSERT(icudtl_subpath || icudtl_system_path || icudtl_system_path_fallback);
+    DEBUG_ASSERT_MSG(!icudtl_system_path_fallback || icudtl_system_path, "icudtl.dat fallback system path is given, but no non-fallback system path.");
+    DEBUG_ASSERT_NOT_NULL(asset_bundle_subpath);
+    DEBUG_ASSERT_NOT_NULL(kernel_blob_subpath);
+    DEBUG_ASSERT_NOT_NULL(app_elf_subpath);
+    DEBUG_ASSERT(app_engine_subpath || engine_dlopen_name || engine_dlopen_name_fallback);
+    DEBUG_ASSERT_MSG(!engine_dlopen_name_fallback || engine_dlopen_name, "flutter engine fallback dlopen name is given, but no non-fallback dlopen name.");
+
+    paths = malloc(sizeof *paths);
+    if (paths == NULL) {
+        return NULL;
+    }
+
+    if (path_exists(app_bundle_path) == false) {
+        LOG_ERROR("App bundle directory \"%s\" does not exist.\n", app_bundle_path);
+        goto fail_free_paths;
+    }
+
+    // Seems like the realpath will always not end with a slash.
+    app_bundle_path_real = realpath(app_bundle_path, NULL);
+    if (app_bundle_path_real == NULL) {
+        goto fail_free_paths;
+    }
+
+    DEBUG_ASSERT(path_exists(app_bundle_path_real));
+
+    // Asset bundle path is the same as the app bundle path in the default filesystem layout,
+    // or <appbundle>/flutter_assets in meta-flutter dunfell / kirkstone layout.
+    ok = asprintf(&asset_bundle_path, "%s/%s", app_bundle_path_real, asset_bundle_subpath);
+    if (ok == -1) {
+        goto fail_free_app_bundle_path_real;
+    }
+
+    if (path_exists(asset_bundle_path) == false) {
+        LOG_ERROR("Asset bundle directory \"%s\" does not exist.\n", asset_bundle_path);
+        goto fail_free_asset_bundle_path;
+    }
+
+    // Find the icudtl.dat file.
+    // Mostly we look in <appbundle>/icudtl.dat or <appbundle>/data/icudtl.dat, /usr/share/flutter/icudtl.dat
+    // or /usr/lib/icudtl.dat.
+    icudtl_path = NULL;
+
+    if (icudtl_subpath != NULL) {
+        ok = asprintf(&icudtl_path, "%s/%s", app_bundle_path_real, icudtl_subpath);
+        if (ok == -1) {
+            goto fail_free_asset_bundle_path;
+        }
+    }
+
+    if (icudtl_system_path != NULL && (icudtl_path == NULL || path_exists(icudtl_path) == false)) {
+        LOG_DEBUG("icudtl file not found at %s.\n", icudtl_path);
+        free(icudtl_path);
+
+        icudtl_path = strdup(icudtl_system_path);
+        if (icudtl_path == NULL) {
+            goto fail_free_asset_bundle_path;
+        }
+    }
+
+    DEBUG_ASSERT_NOT_NULL(icudtl_path);
+
+    if (icudtl_system_path_fallback != NULL || path_exists(icudtl_path) == false) {
+        LOG_DEBUG("icudtl file not found at %s.\n", icudtl_path);
+        free(icudtl_path);
+
+        icudtl_path = strdup(icudtl_system_path_fallback);
+        if (icudtl_path == NULL) {
+            goto fail_free_asset_bundle_path;
+        }
+    }
+
+    DEBUG_ASSERT_NOT_NULL(icudtl_path);
+
+    // We still haven't found it. Fail because we need it to run flutter.
+    if (path_exists(icudtl_path) == false) {
+        LOG_DEBUG("icudtl file not found at %s.\n", icudtl_path);
+        free(icudtl_path);
+
+        LOG_ERROR("icudtl file not found!\n");
+        goto fail_free_asset_bundle_path;
+    }
+
+    // Find the kernel_blob.bin file. Only necessary for JIT (debug) mode.
+    ok = asprintf(&kernel_blob_path, "%s/%s", app_bundle_path_real, kernel_blob_subpath);
+    if (ok == -1) {
+        goto fail_free_asset_bundle_path;
+    }
+
+    if (FLUTTER_RUNTIME_MODE_IS_JIT(runtime_mode) && !path_exists(kernel_blob_path)) {
+        LOG_ERROR("kernel blob file \"%s\" does not exist, but is necessary for debug mode.\n", kernel_blob_path);
+        goto fail_free_kernel_blob_path;
+    }
+
+    // Find the app.so/libapp.so file. Only necessary for AOT (release/profile) mode.
+    ok = asprintf(&app_elf_path, "%s/%s", app_bundle_path_real, app_elf_subpath);
+    if (ok == -1) {
+        goto fail_free_kernel_blob_path;
+    }
+
+    if (FLUTTER_RUNTIME_MODE_IS_AOT(runtime_mode) && !path_exists(app_elf_path)) {
+        LOG_ERROR("app elf file \"%s\" does not exist, but is necessary for release/profile mode.\n", app_elf_path);
+        goto fail_free_app_elf_path;
+    }
+    
+    // Try to find the engine inside the asset bundle. If we don't find it, that's not an error because
+    // it could still be inside /usr/lib and we can just dlopen it using the filename.
+    ok = asprintf(&engine_path, "%s/%s", app_bundle_path_real, app_engine_subpath);
+    if (ok != -1) {
+        goto fail_free_app_elf_path;
+    }
+
+    if (path_exists(engine_path) == false) {
+        free(engine_path);
+        engine_path = NULL;
+    }
+
+    if (engine_dlopen_name != NULL) {
+        dlopen_name_duped = strdup(engine_dlopen_name);
+        if (dlopen_name_duped == NULL) {
+            goto fail_maybe_free_engine_path;
+        }
+    } else {
+        dlopen_name_duped = NULL;
+    }
+
+    if (engine_dlopen_name_fallback != NULL) {
+        dlopen_name_fallback_duped = strdup(engine_dlopen_name_fallback);
+        if (dlopen_name_fallback_duped == NULL) {
+            goto fail_free_dlopen_name_duped;
+        }
+    } else {
+        dlopen_name_fallback_duped = NULL;
+    }
+
+
+    paths->app_bundle_path = app_bundle_path_real;
+    paths->asset_bundle_path = asset_bundle_path;
+    paths->icudtl_path = icudtl_path;
+    paths->kernel_blob_path = kernel_blob_path;
+    paths->app_elf_path = app_elf_path;
+    paths->flutter_engine_path = engine_path;
+    paths->flutter_engine_dlopen_name = dlopen_name_duped;
+    paths->flutter_engine_dlopen_name_fallback = dlopen_name_fallback_duped;
+    return paths;
+
+
+    fail_free_dlopen_name_duped:
+    free(dlopen_name_duped);
+
+    fail_maybe_free_engine_path:
+    if (engine_path != NULL) {
+        free(engine_path);
+    }
+
+    fail_free_app_elf_path:
+    free(app_elf_path);
+
+    fail_free_kernel_blob_path:
+    free(kernel_blob_path);
+    
+    fail_free_asset_bundle_path:
+    free(asset_bundle_path);
+
+    fail_free_app_bundle_path_real:
+    free(app_bundle_path_real);
+
+    fail_free_paths:
+    free(paths);
+    return NULL;
+}
+
+void flutter_paths_free(struct flutter_paths *paths) {
+    free(paths->app_bundle_path);
+    free(paths->asset_bundle_path);
+    free(paths->icudtl_path);
+    free(paths->kernel_blob_path);
+    free(paths->app_elf_path);
+    if (paths->flutter_engine_path != NULL) {
+        free(paths->flutter_engine_path);
+    }
+    if (paths->flutter_engine_dlopen_name != NULL) {
+        free(paths->flutter_engine_dlopen_name);
+    }
+    if (paths->flutter_engine_dlopen_name_fallback != NULL) {
+        free(paths->flutter_engine_dlopen_name_fallback);
+    }
+    free(paths);
+}
+
+struct flutter_paths *fs_layout_flutterpi_resolve(const char *app_bundle_path, enum flutter_runtime_mode runtime_mode) {
+    return resolve(
+        app_bundle_path,
+        runtime_mode,
+        /*        asset bundle subpath */ "",
+        /*              icudtl subpath */ "icudtl.dat",
+        /*          icudtl system path */ "/usr/share/flutter/icudtl.dat",
+        /* icudtl system path fallback */ "/usr/lib/icudtl.dat",
+        /*         kernel blob subpath */ "kernel_blob.bin",
+        /*             app elf subpath */ "app.so",
+        /*      flutter engine subpath */ "libflutter_engine.so",
+        /*          engine dlopen name */ runtime_mode == kDebug   ? "libflutter_engine.so.debug" :
+                                          runtime_mode == kProfile ? "libflutter_engine.so.profile" :
+                                                                     "libflutter_engine.so.release",
+        /* engine dlopen name fallback */ "libflutter_engine.so"
+    );
+}
+
+struct flutter_paths *fs_layout_dunfell_resolve(const char *app_bundle_path, enum flutter_runtime_mode runtime_mode) {
+    return resolve(
+        app_bundle_path,
+        runtime_mode,
+        /*        asset bundle subpath */ "flutter_assets/",
+        /*              icudtl subpath */ "data/icudtl.dat",
+        /*          icudtl system path */ "/usr/share/flutter/icudtl.dat",
+        /* icudtl system path fallback */ NULL,
+        /*         kernel blob subpath */ "flutter_assets/kernel_blob.bin",
+        /*             app elf subpath */ "lib/libapp.so",
+        /*      flutter engine subpath */ "lib/libflutter_engine.so",
+        /*          engine dlopen name */ "libflutter_engine.so",
+        /* engine dlopen name fallback */ NULL
+    );
+}
+
+struct flutter_paths *fs_layout_kirkstone_resolve(const char *app_bundle_path, enum flutter_runtime_mode runtime_mode) {
+    return resolve(
+        app_bundle_path,
+        runtime_mode,
+        /*        asset bundle subpath */ "flutter_assets/",
+        /*              icudtl subpath */ "data/icudtl.dat",
+        /*          icudtl system path */ "/usr/share/flutter/icudtl.dat",
+        /* icudtl system path fallback */ NULL,
+        /*         kernel blob subpath */ "flutter_assets/kernel_blob.bin",
+        /*             app elf subpath */ "lib/libapp.so",
+        /*      flutter engine subpath */ "lib/libflutter_engine.so",
+        /*          engine dlopen name */ "libflutter_engine.so",
+        /* engine dlopen name fallback */ NULL
+    );
+}

--- a/src/filesystem_layout.c
+++ b/src/filesystem_layout.c
@@ -155,11 +155,16 @@ static struct flutter_paths *resolve(
     // Try to find the engine inside the asset bundle. If we don't find it, that's not an error because
     // it could still be inside /usr/lib and we can just dlopen it using the filename.
     ok = asprintf(&engine_path, "%s/%s", app_bundle_path_real, app_engine_subpath);
-    if (ok != -1) {
+    if (ok == -1) {
         goto fail_free_app_elf_path;
     }
 
     if (path_exists(engine_path) == false) {
+        if (engine_dlopen_name == NULL && engine_dlopen_name_fallback == NULL) {
+            LOG_ERROR("flutter engine file \"%s\" does not exist.\n", engine_path);
+            goto fail_maybe_free_engine_path;
+        }
+
         free(engine_path);
         engine_path = NULL;
     }
@@ -255,27 +260,11 @@ struct flutter_paths *fs_layout_flutterpi_resolve(const char *app_bundle_path, e
     );
 }
 
-struct flutter_paths *fs_layout_dunfell_resolve(const char *app_bundle_path, enum flutter_runtime_mode runtime_mode) {
+struct flutter_paths *fs_layout_metaflutter_resolve(const char *app_bundle_path, enum flutter_runtime_mode runtime_mode) {
     return resolve(
         app_bundle_path,
         runtime_mode,
-        /*        asset bundle subpath */ "flutter_assets/",
-        /*              icudtl subpath */ "data/icudtl.dat",
-        /*          icudtl system path */ "/usr/share/flutter/icudtl.dat",
-        /* icudtl system path fallback */ NULL,
-        /*         kernel blob subpath */ "flutter_assets/kernel_blob.bin",
-        /*             app elf subpath */ "lib/libapp.so",
-        /*      flutter engine subpath */ "lib/libflutter_engine.so",
-        /*          engine dlopen name */ "libflutter_engine.so",
-        /* engine dlopen name fallback */ NULL
-    );
-}
-
-struct flutter_paths *fs_layout_kirkstone_resolve(const char *app_bundle_path, enum flutter_runtime_mode runtime_mode) {
-    return resolve(
-        app_bundle_path,
-        runtime_mode,
-        /*        asset bundle subpath */ "flutter_assets/",
+        /*        asset bundle subpath */ "data/flutter_assets/",
         /*              icudtl subpath */ "data/icudtl.dat",
         /*          icudtl system path */ "/usr/share/flutter/icudtl.dat",
         /* icudtl system path fallback */ NULL,

--- a/src/flutter-pi.c
+++ b/src/flutter-pi.c
@@ -2338,12 +2338,10 @@ static bool path_exists(const char *path) {
 static struct flutter_paths *setup_paths(enum flutter_runtime_mode runtime_mode, const char *app_bundle_path) {
 #if defined(FILESYSTEM_LAYOUT_DEFAULT)
     return fs_layout_flutterpi_resolve(app_bundle_path, runtime_mode);
-#elif defined(FILESYSTEM_LAYOUT_DUNFELL)
-    return fs_layout_dunfell_resolve(app_bundle_path, runtime_mode);
-#elif defined(FILESYSTEM_LAYOUT_KIRKSTONE)
-    return fs_layout_kirkstone_resolve(app_bundle_path, runtime_mode);
+#elif defined(FILESYSTEM_LAYOUT_METAFLUTTER)
+    return fs_layout_metaflutter_resolve(app_bundle_path, runtime_mode);
 #else
-    #error "Exactly one of FILESYSTEM_LAYOUT_DEFAULT, FILESYSTEM_LAYOUT_DUNFELL and FILESYSTEM_LAYOUT_KIRKSTONE must be defined."
+    #error "Exactly one of FILESYSTEM_LAYOUT_DEFAULT or FILESYSTEM_LAYOUT_METAFLUTTER must be defined."
     return NULL;
 #endif
 }

--- a/src/flutter-pi.c
+++ b/src/flutter-pi.c
@@ -1847,7 +1847,7 @@ static int init_application(void) {
         }
     }
 
-    if (engine_handle == NULL) {
+    if (engine_handle == NULL && flutterpi.flutter.paths->flutter_engine_dlopen_name != NULL) {
         engine_handle = dlopen(flutterpi.flutter.paths->flutter_engine_dlopen_name, RTLD_LOCAL | RTLD_NOW);
         if (engine_handle == NULL) {
             LOG_DEBUG(
@@ -1858,7 +1858,7 @@ static int init_application(void) {
         }
     }
 
-    if (engine_handle == NULL) {
+    if (engine_handle == NULL && flutterpi.flutter.paths->flutter_engine_dlopen_name_fallback != NULL) {
         engine_handle = dlopen(flutterpi.flutter.paths->flutter_engine_dlopen_name_fallback, RTLD_LOCAL | RTLD_NOW);
         if (engine_handle == NULL) {
             LOG_DEBUG(

--- a/src/flutter-pi.c
+++ b/src/flutter-pi.c
@@ -1848,59 +1848,25 @@ static int init_application(void) {
     }
 
     if (engine_handle == NULL) {
-#ifdef ENGINE_DLOPEN_NAME_RELEASE
-        if (runtime_mode == kRelease) {
-            engine_handle = dlopen(ENGINE_DLOPEN_NAME_RELEASE, RTLD_LOCAL | RTLD_NOW);
-            if (engine_handle == NULL) {
-                LOG_DEBUG("Info: Could not load " ENGINE_DLOPEN_NAME_RELEASE ". dlopen: %s.\n", dlerror());
-            }
-        } 
-#endif
-#ifdef ENGINE_DLOPEN_NAME_PROFILE
-        if (runtime_mode == kProfile) {
-            engine_handle = dlopen(ENGINE_DLOPEN_NAME_PROFILE, RTLD_LOCAL | RTLD_NOW);
-            if (engine_handle == NULL) {
-                LOG_DEBUG("Info: Could not load " ENGINE_DLOPEN_NAME_PROFILE ". dlopen: %s.\n", dlerror());
-            }
-
+        engine_handle = dlopen(flutterpi.flutter.paths->flutter_engine_dlopen_name, RTLD_LOCAL | RTLD_NOW);
+        if (engine_handle == NULL) {
+            LOG_DEBUG(
+                "Info: Could not load flutter engine. dlopen(\"%s\"): %s.\n",
+                flutterpi.flutter.paths->flutter_engine_dlopen_name,
+                dlerror()
+            );
         }
-#endif
-#ifdef ENGINE_DLOPEN_NAME_DEBUG
-        if (runtime_mode == kDebug) {
-            engine_handle = dlopen(ENGINE_DLOPEN_NAME_DEBUG, RTLD_LOCAL | RTLD_NOW);
-            if (engine_handle == NULL) {
-                LOG_DEBUG("Info: Could not load " ENGINE_DLOPEN_NAME_DEBUG ". dlopen: %s.\n", dlerror());
-            }
-        }
-#endif
     }
 
     if (engine_handle == NULL) {
-#ifdef ENGINE_DLOPEN_NAME_RELEASE_FALLBACK
-        if (runtime_mode == kRelease) {
-            engine_handle = dlopen(ENGINE_DLOPEN_NAME_RELEASE_FALLBACK, RTLD_LOCAL | RTLD_NOW);
-            if (engine_handle == NULL) {
-                LOG_DEBUG("Info: Could not load " ENGINE_DLOPEN_NAME_RELEASE_FALLBACK ". dlopen: %s.\n", dlerror());
-            }
-        } 
-#endif
-#ifdef ENGINE_DLOPEN_NAME_PROFILE_FALLBACK
-        if (runtime_mode == kProfile) {
-            engine_handle = dlopen(ENGINE_DLOPEN_NAME_PROFILE_FALLBACK, RTLD_LOCAL | RTLD_NOW);
-            if (engine_handle == NULL) {
-                LOG_DEBUG("Info: Could not load " ENGINE_DLOPEN_NAME_PROFILE_FALLBACK ". dlopen: %s.\n", dlerror());
-            }
-
+        engine_handle = dlopen(flutterpi.flutter.paths->flutter_engine_dlopen_name_fallback, RTLD_LOCAL | RTLD_NOW);
+        if (engine_handle == NULL) {
+            LOG_DEBUG(
+                "Info: Could not load flutter engine. dlopen(\"%s\"): %s.\n",
+                flutterpi.flutter.paths->flutter_engine_dlopen_name_fallback,
+                dlerror()
+            );
         }
-#endif
-#ifdef ENGINE_DLOPEN_NAME_DEBUG_FALLBACK
-        if (runtime_mode == kDebug) {
-            engine_handle = dlopen(ENGINE_DLOPEN_NAME_DEBUG_FALLBACK, RTLD_LOCAL | RTLD_NOW);
-            if (engine_handle == NULL) {
-                LOG_DEBUG("Info: Could not load " ENGINE_DLOPEN_NAME_DEBUG_FALLBACK ". dlopen: %s.\n", dlerror());
-            }
-        }
-#endif
     }
 
     if (engine_handle == NULL) {

--- a/src/plugins/omxplayer_video_player.c
+++ b/src/plugins/omxplayer_video_player.c
@@ -1148,7 +1148,7 @@ static int on_create(
     player->player_id = omxpvidpp.next_unused_player_id++;
     player->mgr = mgr;
     if (asset != NULL) {
-        snprintf(player->video_uri, sizeof(player->video_uri), "%s/%s", flutterpi.flutter.asset_bundle_path, asset);
+        snprintf(player->video_uri, sizeof(player->video_uri), "%s/%s", flutterpi.flutter.paths->asset_bundle_path, asset);
     } else {
         strncpy(player->video_uri, uri, sizeof(player->video_uri));
     }


### PR DESCRIPTION
Allows configuring the filesystem layout of the flutter artifacts, so where flutter-pi looks for the flutter engine, icudtl.dat, asset bundle, etc.

Adds a build flag for using the meta-flutter layout:
```bash
$ cmake ... -DFILESYSTEM_LAYOUT=meta-flutter ...
```

Implements #278.