### PR TITLE
Use XR24 pixel format for base canvas

### DIFF
--- a/include/pixel_format.h
+++ b/include/pixel_format.h
@@ -44,7 +44,7 @@ COMPILE_ASSERT(kMax_PixFmt == kRGBA8888_FpiPixelFormat);
 
 #define PIXFMT_LIST(V) \
     V( "RGB 5:6:5",    "RGB565",  kRGB565_FpiPixelFormat,   /*bpp*/ 16, /*opaque*/ true,  /*R*/ 5, 11, /*G*/ 6, 5,  /*B*/ 5, 0,  /*A*/ 0, 0,  /*GBM fourcc*/ GBM_FORMAT_RGB565,   /*DRM fourcc*/ DRM_FORMAT_RGB565) \
-    V("ARGB 8:8:8:8", "ARGB8888", kARGB8888_FpiPixelFormat, /*bpp*/ 32, /*opaque*/ false, /*R*/ 8, 16, /*G*/ 8, 8,  /*B*/ 8, 0,  /*A*/ 8, 24, /*GBM fourcc*/ GBM_FORMAT_ARGB8888, /*DRM fourcc*/ DRM_FORMAT_RGB565) \
+    V("ARGB 8:8:8:8", "ARGB8888", kARGB8888_FpiPixelFormat, /*bpp*/ 32, /*opaque*/ false, /*R*/ 8, 16, /*G*/ 8, 8,  /*B*/ 8, 0,  /*A*/ 8, 24, /*GBM fourcc*/ GBM_FORMAT_ARGB8888, /*DRM fourcc*/ DRM_FORMAT_ARGB8888) \
     V("XRGB 8:8:8:8", "XRGB8888", kXRGB8888_FpiPixelFormat, /*bpp*/ 32, /*opaque*/ true,  /*R*/ 8, 16, /*G*/ 8, 8,  /*B*/ 8, 0,  /*A*/ 0, 24, /*GBM fourcc*/ GBM_FORMAT_XRGB8888, /*DRM fourcc*/ DRM_FORMAT_XRGB8888) \
     V("BGRA 8:8:8:8", "BGRA8888", kBGRA8888_FpiPixelFormat, /*bpp*/ 32, /*opaque*/ false, /*R*/ 8,  8, /*G*/ 8, 16, /*B*/ 8, 24, /*A*/ 8, 0,  /*GBM fourcc*/ GBM_FORMAT_BGRA8888, /*DRM fourcc*/ DRM_FORMAT_BGRA8888) \
     V("RGBA 8:8:8:8", "RGBA8888", kRGBA8888_FpiPixelFormat, /*bpp*/ 32, /*opaque*/ false, /*R*/ 8, 24, /*G*/ 8, 16, /*B*/ 8, 8,  /*A*/ 8, 0,  /*GBM fourcc*/ GBM_FORMAT_RGBA8888, /*DRM fourcc*/ DRM_FORMAT_RGBA8888)

--- a/src/flutter-pi.c
+++ b/src/flutter-pi.c
@@ -1597,9 +1597,10 @@ static int init_display(void) {
      * GBM INITIALIZATION *
      **********************/
     flutterpi.gbm.device = gbm_create_device(flutterpi.drm.drmdev->fd);
-    flutterpi.gbm.format = DRM_FORMAT_ARGB8888;
     flutterpi.gbm.surface = NULL;
     flutterpi.gbm.modifier = DRM_FORMAT_MOD_LINEAR;
+    if (!flutterpi.gbm.format)
+        flutterpi.gbm.format = DRM_FORMAT_ARGB8888;
 
     flutterpi.gbm.surface = gbm_surface_create_with_modifiers(flutterpi.gbm.device, flutterpi.display.width, flutterpi.display.height, flutterpi.gbm.format, &flutterpi.gbm.modifier, 1);
     if (flutterpi.gbm.surface == NULL) {

--- a/src/flutter-pi.c
+++ b/src/flutter-pi.c
@@ -1600,7 +1600,7 @@ static int init_display(void) {
     flutterpi.gbm.surface = NULL;
     flutterpi.gbm.modifier = DRM_FORMAT_MOD_LINEAR;
     if (!flutterpi.gbm.format)
-        flutterpi.gbm.format = DRM_FORMAT_ARGB8888;
+        flutterpi.gbm.format = DRM_FORMAT_XRGB8888;
 
     flutterpi.gbm.surface = gbm_surface_create_with_modifiers(flutterpi.gbm.device, flutterpi.display.width, flutterpi.display.height, flutterpi.gbm.format, &flutterpi.gbm.modifier, 1);
     if (flutterpi.gbm.surface == NULL) {


### PR DESCRIPTION
The base canvas can seldom be transparent and require alpha. To make this tool more compatible with contemporary hardware, make base canvas XR24 pixel format, i.e. without alpha . Fix the --pixelformat parameter handling in the process too.