### PR TITLE
Fix offset used before range check

### DIFF
--- a/src/platformchannel.c
+++ b/src/platformchannel.c
@@ -1556,7 +1556,7 @@ bool jsvalue_equals(struct json_value *a, struct json_value *b) {
 				
 				int j = 0;
 				while (j < a->size) {
-					while (_keyInBAlsoInA[j] && (j < a->size))  j++;	// skip all keys with _keyInBAlsoInA set to true.
+					while ((j < a->size) && _keyInBAlsoInA[j])  j++;	// skip all keys with _keyInBAlsoInA set to true.
 					if (strcmp(key, b->keys[j]) != 0)   		j++;	// if b->keys[j] is not equal to "key", continue searching
 					else {
 						_keyInBAlsoInA[j] = true;
@@ -1682,7 +1682,7 @@ bool stdvalue_equals(struct std_value *a, struct std_value *b) {
 				
 				int j = 0;
 				while (j < a->size) {
-					while (_keyInBAlsoInA[j] && (j < a->size))  j++;	// skip all keys with _keyInBAlsoInA set to true.
+					while ((j < a->size) && _keyInBAlsoInA[j])  j++;	// skip all keys with _keyInBAlsoInA set to true.
 					if (stdvalue_equals(key, b->keys + j) == false) {
 						j++;	// if b->keys[j] is not equal to "key", continue searching
 					} else {


### PR DESCRIPTION
These uses of offset 'j' should follow the range check.