### PR TITLE
Check return value of sscanf()

### DIFF
--- a/src/flutter-pi.c
+++ b/src/flutter-pi.c
@@ -2387,7 +2387,7 @@ static bool parse_cmd_args(int argc, char **argv) {
                 unsigned int width_mm, height_mm;
 
                 ok = sscanf(optarg, "%u,%u", &width_mm, &height_mm);
-                if ((ok == 0) || (ok == EOF)) {
+                if (ok != 2) {
                     LOG_ERROR("ERROR: Invalid argument for --dimensions passed.\n%s", usage);
                     return false;
                 }


### PR DESCRIPTION
Variables width_mm and height_mm are read, but may not have been written. They should be guarded by a check that the call to sscanf returns at least 2.