### PR TITLE
Update instructions to use flutterpi-tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
   - Currently only supported on linux at the moment.
   - Requires flutter SDK > 3.10.5
   - Engine binaries no longer need to be installed on the target system.
-  - See updated [Configuring your Raspberry Pi](#configuring-your-raspberry-pi) and [Building the App](#building-the-app-new-method-linux-only) sections below.
+  - See updated [Building flutter-pi on the Raspberry Pi](#-building-flutter-pi-on-the-raspberry-pi) and [Building the App](#building-the-app-new-method-linux-only) sections below.
 - There's now a new video player based on gstreamer. See [gstreamer video player](#gstreamer-video-player) section.
 - The new latest flutter gallery commit for flutter 3.7 is `9776b9fd916635e10a32bd426fcd7a20c3841faf`
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
   - Engine binaries no longer need to be installed on the target system.
   - See updated [Building flutter-pi on the Raspberry Pi](#-building-flutter-pi-on-the-raspberry-pi) and [Building the App](#building-the-app-new-method-linux-only) sections below.
 - There's now a new video player based on gstreamer. See [gstreamer video player](#gstreamer-video-player) section.
-- The new latest flutter gallery commit for flutter 3.7 is `9776b9fd916635e10a32bd426fcd7a20c3841faf`
+- The new latest flutter gallery commit for flutter 3.10 is `d77920b4ced4a105ad35659fbe3958800d418fb9`
 
 # flutter-pi
 A light-weight Flutter Engine Embedder for Raspberry Pi. Inspired by https://github.com/chinmaygarde/flutter_from_scratch.
@@ -183,7 +183,7 @@ _Example:_
 ```bash
 git clone https://github.com/flutter/gallery.git flutter_gallery
 cd flutter_gallery
-git checkout 9776b9fd916635e10a32bd426fcd7a20c3841faf
+git checkout d77920b4ced4a105ad35659fbe3958800d418fb9
 flutterpi_tool build --release --cpu=pi4
 rsync -a ./build/flutter_assets/ pi@raspberrypi:/home/pi/flutter_gallery/
 ```
@@ -223,7 +223,7 @@ rsync -a ./build/flutter_assets/ pi@raspberrypi:/home/pi/flutter_gallery/
 ```bash
 git clone https://github.com/flutter/gallery.git flutter_gallery
 cd flutter_gallery
-git checkout 9776b9fd916635e10a32bd426fcd7a20c3841faf
+git checkout d77920b4ced4a105ad35659fbe3958800d418fb9
 flutter build bundle
 rsync -a ./build/flutter_assets/ pi@raspberrypi:/home/pi/flutter_gallery/
 ```
@@ -232,7 +232,7 @@ rsync -a ./build/flutter_assets/ pi@raspberrypi:/home/pi/flutter_gallery/
 <details>
   <summary>More information</summary>
     
-  - flutter_gallery is developed against flutter master. `9776b9fd916635e10a32bd426fcd7a20c3841faf` is currently the latest flutter gallery
+  - flutter_gallery is developed against flutter master. `d77920b4ced4a105ad35659fbe3958800d418fb9` is currently the latest flutter gallery
     commit working with flutter stable.
 </details>
 
@@ -296,7 +296,7 @@ rsync -a ./build/flutter_assets/ pi@raspberrypi:/home/pi/flutter_gallery/
     git clone https://github.com/flutter/gallery.git flutter_gallery
     git clone --depth 1 https://github.com/ardera/flutter-engine-binaries-for-arm.git engine-binaries
     cd flutter_gallery
-    git checkout 9776b9fd916635e10a32bd426fcd7a20c3841faf
+    git checkout d77920b4ced4a105ad35659fbe3958800d418fb9
     flutter build bundle
     C:\flutter\bin\cache\dart-sdk\bin\dart.exe ^
       C:\flutter\bin\cache\dart-sdk\bin\snapshots\frontend_server.dart.snapshot ^

--- a/README.md
+++ b/README.md
@@ -327,15 +327,24 @@ rsync -a ./build/flutter_assets/ pi@raspberrypi:/home/pi/flutter_gallery/
 
 ### Running your App with flutter-pi
 ```txt
+pi@hpi4:~ $ flutter-pi --help
+flutter-pi - run flutter apps on your Raspberry Pi.
+
 USAGE:
-  flutter-pi [options] <asset bundle path> [flutter engine options]
+  flutter-pi [options] <bundle path> [flutter engine options]
 
 OPTIONS:
   --release                  Run the app in release mode. The AOT snapshot
-                             of the app ("app.so") must be located inside the
-                             asset bundle directory.
+                             of the app must be located inside the bundle directory.
                              This also requires a libflutter_engine.so that was
                              built with --runtime-mode=release.
+
+  --profile                  Run the app in profile mode. The AOT snapshot
+                             of the app must be located inside the bundle directory.
+                             This also requires a libflutter_engine.so that was
+                             built with --runtime-mode=profile.
+
+  --vulkan                   Use vulkan for rendering.
 
   -o, --orientation <orientation>  Start the app in this orientation. Valid
                              for <orientation> are: portrait_up, landscape_left,
@@ -359,23 +368,14 @@ OPTIONS:
                              to calculate the flutter device-pixel-ratio, which
                              in turn basically "scales" the UI.
 
-  -i, --input <glob pattern> Appends all files matching this glob pattern to the
-                             list of input (touchscreen, mouse, touchpad,
-                             keyboard) devices. Brace and tilde expansion is
-                             enabled.
-                             Every file that matches this pattern, but is not
-                             a valid touchscreen / -pad, mouse or keyboard is
-                             silently ignored.
-                             If no -i options are given, flutter-pi will try to
-                             use all input devices assigned to udev seat0.
-                             If that fails, or udev is not installed, flutter-pi
-                             will fallback to using all devices matching
-                             "/dev/input/event*" as inputs.
-                             In most cases, there's no need to specify this
-                             option.
-                             Note that you need to properly escape each glob
-                             pattern you use as a parameter so it isn't
-                             implicitly expanded by your shell.
+  --pixelformat <format>     Selects the pixel format to use for the framebuffers.
+                             If this is not specified, a good pixel format will
+                             be selected automatically.
+                             Available pixel formats: RGB565, ARGB4444, XRGB4444, ARGB1555, XRGB1555, ARGB8888, XRGB8888, BGRA8888, BGRX8888, RGBA8888, RGBX8888, 
+  --videomode widthxheight
+  --videomode widthxheight@hz  Uses an output videomode that satisfies the argument.
+                             If no hz value is given, the highest possible refreshrate
+                             will be used.
 
   -h, --help                 Show this help and exit.
 
@@ -385,6 +385,8 @@ EXAMPLES:
   flutter-pi -o portrait_up ./my_app
   flutter-pi -r 90 ./my_app
   flutter-pi -d "155, 86" ./my_app
+  flutter-pi --videomode 1920x1080 ./my_app
+  flutter-pi --videomode 1280x720@60 ./my_app
 
 SEE ALSO:
   Author:  Hannes Winkler, a.k.a ardera
@@ -392,9 +394,9 @@ SEE ALSO:
   License: MIT
 
   For instructions on how to build an asset bundle or an AOT snapshot
-    of your app, please see the linked git repository.
+    of your app, please see the linked github repository.
   For a list of options you can pass to the flutter engine, look here:
-    https://github.com/flutter/engine/blob/master/shell/common/switches.h
+    https://github.com/flutter/engine/blob/main/shell/common/switches.h
 ```
 
 `<asset bundle path>` is the path of the flutter asset bundle directory (i.e. the directory containing `kernel_blob.bin`)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,9 @@
 ## 📰 NEWS
+- There's now flutterpi tool to make building the app easier: https://pub.dev/packages/flutterpi_tool
+  - Currently only supported on linux at the moment.
+  - Requires flutter SDK > 3.10.5
+  - Engine binaries no longer need to be installed on the target system.
+  - See updated [Configuring your Raspberry Pi](#configuring-your-raspberry-pi) and [Building the App](#building-the-app-new-method-linux-only) sections below.
 - There's now a new video player based on gstreamer. See [gstreamer video player](#gstreamer-video-player) section.
 - The new latest flutter gallery commit for flutter 3.7 is `9776b9fd916635e10a32bd426fcd7a20c3841faf`
 
@@ -32,10 +37,9 @@ If you encounter issues running flutter-pi on any of the supported platforms lis
 1.2 [Compiling](#compiling)  
 2. **[Running your App on the Raspberry Pi](#-running-your-app-on-the-raspberry-pi)**  
 2.1 [Configuring your Raspberry Pi](#configuring-your-raspberry-pi)  
-2.2 [Building the Asset bundle](#building-the-asset-bundle)  
-2.3 [Building the `app.so` (for running your app in Release/Profile mode)](#building-the-appso-for-running-your-app-in-releaseprofile-mode)  
-2.4 [Running your App with flutter-pi](#running-your-app-with-flutter-pi)  
-2.5 [gstreamer video player](#gstreamer-video-player)
+2.2 [Building the App](#building-the-app-new-method-linux-only)  
+2.3 [Running your App with flutter-pi](#running-your-app-with-flutter-pi)  
+2.4 [gstreamer video player](#gstreamer-video-player)  
 3. **[Performance](#-performance)**  
 3.1 [Graphics Performance](#graphics-performance)  
 3.2 [Touchscreen latency](#touchscreen-latency)  
@@ -146,20 +150,24 @@ If you encounter issues running flutter-pi on any of the supported platforms lis
 </details>
 
 ### Building the App (New Method, Linux-only)
-- The asset bundle must be built on your development machine. Note that you can't use a Raspberry Pi as your development machine.
+The app must be built on your development machine. Note that you can't use a Raspberry Pi as your development machine.
 
 _One-time setup:_
-1. Make sure you've installed the flutter SDK. Only flutter SDK >= 3.10.5 is supported for the new way at the moment.
+1. Make sure you've installed the flutter SDK. Only flutter SDK >= 3.10.5 is supported for the new method at the moment.
 2. Install the [flutterpi_tool](https://pub.dev/packages/flutterpi_tool):
    Run `flutter pub global activate flutterpi_tool` (One time only)
+3. If running `flutterpi_tool` directly doesn't work, follow https://dart.dev/tools/pub/cmd/pub-global#running-a-script-from-your-path
+   to add the dart global bin directory to your path.  
+   Alternatively, you can launch the tool via:
+   `flutter pub global run flutterpi_tool ...`
 
 _Building the app bundle:_
 1. Open terminal or commandline and `cd` into your app directory.
 2. Run `flutterpi_tool build` to build the app.
     - This will build the app for ARM 32-bit debug mode.
     - `flutterpi_tool build --help` gives more usage information.
-    - For example, to build for 64-bit ARM, release mode, with a Raspberry Pi 4 tuned engine, use:
-      - `flutterpi_tool build --arch=arm64 --cpu=pi4 --release`
+    - For example, to build for 64-bit ARM, release mode, with a Raspberry Pi 4 tuned engine, use:  
+       `flutterpi_tool build --arch=arm64 --cpu=pi4 --release`
 3. Deploy the bundle to the Raspberry Pi using `rsync` or `scp`:
     - Using `rsync` (available on linux and macOS or on Windows when using [WSL](https://docs.microsoft.com/de-de/windows/wsl/install-win10))
        ```bash
@@ -171,7 +179,6 @@ _Building the app bundle:_
        ```
 
 _Example:_
-
 1. We'll build the asset bundle for `flutter_gallery` and deploy it using `rsync` to a Raspberry Pi 4 in this example.
 ```bash
 git clone https://github.com/flutter/gallery.git flutter_gallery


### PR DESCRIPTION
- flutter-pi tool was just published at https://pub.dev/packages/flutterpi_tool.
- update the instructions to use the flutterpi tool for building the app
- still leave the old method in a `<details>` tag
- engine-binaries no longer need to be installed on the target