### PR TITLE
audioplayers: Rename player-id to playerId as it should be

### DIFF
--- a/src/plugins/audioplayers/player.c
+++ b/src/plugins/audioplayers/player.c
@@ -219,7 +219,7 @@ void audio_player_on_media_error(struct audio_player *self, GError *error, gchar
             self->channel,
             "audio.onError",
             &STDMAP2(
-                STDSTRING("player_id"),
+                STDSTRING("playerId"),
                 STDSTRING(self->player_id),
                 STDSTRING("value"),
                 STDSTRING(error_message)
@@ -251,7 +251,7 @@ void audio_player_on_position_update(struct audio_player *self) {
             self->channel,
             "audio.onCurrentPosition",
             &STDMAP2(
-                STDSTRING("player_id"),
+                STDSTRING("playerId"),
                 STDSTRING(self->player_id),
                 STDSTRING("value"),
                 STDINT64(audio_player_get_position(self))
@@ -269,7 +269,7 @@ void audio_player_on_duration_update(struct audio_player *self) {
             self->channel,
             "audio.onDuration",
             &STDMAP2(
-                STDSTRING("player_id"),
+                STDSTRING("playerId"),
                 STDSTRING(self->player_id),
                 STDSTRING("value"),
                 STDINT64(audio_player_get_duration(self))
@@ -288,7 +288,7 @@ void audio_player_on_seek_completed(struct audio_player *self) {
             self->channel,
             "audio.onSeekComplete",
             &STDMAP2(
-                STDSTRING("player_id"),
+                STDSTRING("playerId"),
                 STDSTRING(self->player_id),
                 STDSTRING("value"),
                 STDBOOL(true)
@@ -310,7 +310,7 @@ void audio_player_on_playback_ended(struct audio_player *self) {
             self->channel,
             "audio.onComplete",
             &STDMAP2(
-                STDSTRING("player_id"),
+                STDSTRING("playerId"),
                 STDSTRING(self->player_id),
                 STDSTRING("value"),
                 STDBOOL(true)

--- a/src/plugins/audioplayers/plugin.c
+++ b/src/plugins/audioplayers/plugin.c
@@ -35,10 +35,10 @@ static int on_local_method_call(char *channel, struct platch_obj *object, Flutte
         return platch_respond_illegal_arg_std(responsehandle, "Expected `arg` to be a map.");
     }
 
-    tmp = stdmap_get_str(&object->std_arg, "player_id");
+    tmp = stdmap_get_str(&object->std_arg, "playerId");
     if (tmp == NULL || !STDVALUE_IS_STRING(*tmp)) {
         LOG_ERROR("Call missing mandatory parameter player_id.\n");
-        return platch_respond_illegal_arg_std(responsehandle, "Expected `arg['player_id'] to be a string.");
+        return platch_respond_illegal_arg_std(responsehandle, "Expected `arg['playerId'] to be a string.");
     }
     player_id = STDVALUE_AS_STRING(*tmp);
     tmp = stdmap_get_str(args, "mode");


### PR DESCRIPTION
As I used my own fork all this time I didn't notice that during preparations of PR I renamed `playerId` into `player-id` when querying variables from channel 😢 

Reference:
https://github.com/bluefireteam/audioplayers/blob/51ab6b4a1271c0da635c3cc8fdb475a542018427/packages/audioplayers_linux/linux/audioplayers_linux_plugin.cc#L106