### PR TITLE
fix multiplanar framebuffers

### DIFF
--- a/src/egl_gbm_render_surface.c
+++ b/src/egl_gbm_render_surface.c
@@ -403,16 +403,10 @@ static int egl_gbm_render_surface_present_kms(struct surface *s, const struct fl
         ASSERT_NOT_NULL(drmdev);
 
         TRACER_BEGIN(egl_surface->surface.tracer, "drmdev_add_fb (non-opaque)");
-        fb_id = drmdev_add_fb(
+        fb_id = drmdev_add_fb_from_gbm_bo(
             drmdev,
-            gbm_bo_get_width(bo),
-            gbm_bo_get_height(bo),
-            egl_surface->pixel_format,
-            gbm_bo_get_handle(bo).u32,
-            gbm_bo_get_stride(bo),
-            gbm_bo_get_offset(bo, 0),
-            gbm_bo_get_modifier(bo) != DRM_FORMAT_MOD_INVALID,
-            gbm_bo_get_modifier(bo)
+            bo,
+            /* cast_opaque */ false
         );
         TRACER_END(egl_surface->surface.tracer, "drmdev_add_fb (non-opaque)");
 
@@ -425,16 +419,10 @@ static int egl_gbm_render_surface_present_kms(struct surface *s, const struct fl
         // if this EGL surface is non-opaque and has an opaque equivalent
         if (!get_pixfmt_info(egl_surface->pixel_format)->is_opaque &&
             pixfmt_opaque(egl_surface->pixel_format) != egl_surface->pixel_format) {
-            opaque_fb_id = drmdev_add_fb(
+            opaque_fb_id = drmdev_add_fb_from_gbm_bo(
                 drmdev,
-                gbm_bo_get_width(bo),
-                gbm_bo_get_height(bo),
-                pixfmt_opaque(egl_surface->pixel_format),
-                gbm_bo_get_handle(bo).u32,
-                gbm_bo_get_stride(bo),
-                gbm_bo_get_offset(bo, 0),
-                gbm_bo_get_modifier(bo) != DRM_FORMAT_MOD_INVALID,
-                gbm_bo_get_modifier(bo)
+                bo,
+                /* cast_opaque */ true
             );
             if (opaque_fb_id == 0) {
                 ok = EIO;

--- a/src/egl_gbm_render_surface.c
+++ b/src/egl_gbm_render_surface.c
@@ -243,6 +243,7 @@ static int egl_gbm_render_surface_init(
     }
     s->locked_front_fb = NULL;
 #ifdef DEBUG
+    s->n_locked_fbs = 0;
     s->logged_format_and_modifier = false;
 #endif
     return 0;

--- a/src/modesetting.h
+++ b/src/modesetting.h
@@ -686,6 +686,12 @@ uint32_t drmdev_add_fb_from_dmabuf_multiplanar(
     const uint64_t modifiers[4]
 );
 
+uint32_t drmdev_add_fb_from_gbm_bo(
+    struct drmdev *drmdev,
+    struct gbm_bo *bo,
+    bool cast_opaque
+);
+
 int drmdev_rm_fb_locked(struct drmdev *drmdev, uint32_t fb_id);
 
 int drmdev_rm_fb(struct drmdev *drmdev, uint32_t fb_id);

--- a/src/pixel_format.h
+++ b/src/pixel_format.h
@@ -395,6 +395,27 @@ ATTR_CONST static inline enum pixfmt get_pixfmt_for_drm_format(uint32_t fourcc) 
     return PIXFMT_RGB565;
 }
 
+ATTR_CONST static inline bool has_pixfmt_for_gbm_format(uint32_t fourcc) {
+    for (int i = 0; i < n_pixfmt_infos; i++) {
+        if (get_pixfmt_info(i)->gbm_format == fourcc) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+ATTR_CONST static inline enum pixfmt get_pixfmt_for_gbm_format(uint32_t fourcc) {
+    for (int i = 0; i < n_pixfmt_infos; i++) {
+        if (get_pixfmt_info(i)->gbm_format == fourcc) {
+            return i;
+        }
+    }
+
+    ASSERT_MSG(false, "Check has_pixfmt_for_gbm_format if an enum pixfmt exists for a specific GBM fourcc.");
+    return PIXFMT_RGB565;
+}
+
 COMPILE_ASSERT(PIXFMT_RGB565 == 0);
 
 #define ASSERT_PIXFMT_VALID(format) ASSERT_MSG(format >= PIXFMT_RGB565 && format <= PIXFMT_MAX, "Invalid pixel format")


### PR DESCRIPTION
Implement uploading multi-planar framebuffers. Mutli-planar framebuffers can arise from normal RGB pixel formats when using modifiers (on Intel, the second plane is used as a Color-Control-Surface for framebuffer compression for example)

- fixes #355
