### PR TITLE
src/egl_gbm_render_surface: properly fallback to surface with no modifier

### DIFF
--- a/src/egl_gbm_render_surface.c
+++ b/src/egl_gbm_render_surface.c
@@ -146,6 +146,7 @@ static int egl_gbm_render_surface_init(
     }
 #endif
 
+    gbm_surface = NULL;
     if (allowed_modifiers != NULL) {
         gbm_surface = gbm_surface_create_with_modifiers(
             gbm_device,
@@ -158,9 +159,10 @@ static int egl_gbm_render_surface_init(
         if (gbm_surface == NULL) {
             ok = errno;
             LOG_ERROR("Couldn't create GBM surface for rendering. gbm_surface_create_with_modifiers: %s\n", strerror(ok));
-            return ok;
+            LOG_ERROR("Will retry without modifiers\n");
         }
-    } else {
+    }
+    if (gbm_surface == NULL) {
         gbm_surface = gbm_surface_create(
             gbm_device,
             size.x,


### PR DESCRIPTION
In 869fa7fcfbeb, we added a fallback to be able to create an EGL sruface when the driver do not support modifiers, like the llvmpipe software renderer (or like some proprietary drivers, like the MALI ones), as reported in #269 [0].

However, in c6537673c9b6, there was a big overhaul of renderer infrastructure. That commit lost the with-modifiers code path and only kept the without-modifiers fallback one (i.e. it only kept the call to gbm_surface_create(), not to gbm_surface_create_with_modifiers()).

Then in b0d09f5032a4, the with-modifier code path was re-instated, but in a way that made it exclusive with the without-modifiers one. That is, the without-modifiers code path was not a fallback to when the other failed.

Re-instate the fallback mechanism as initially implemented.

[0] https://github.com/ardera/flutter-pi/issues/269