### PR TITLE
GL Offscreen Rendering Support

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:bookworm
+FROM mcr.microsoft.com/devcontainers/base:debian12
 
 RUN env DEBIAN_FRONTEND=noninteractive \
     apt-get update
@@ -7,4 +7,17 @@ RUN env DEBIAN_FRONTEND=noninteractive \
     apt-get install -y \
     gdb git cmake ninja-build pkg-config nano clang clang-format clang-tidy clang-tools \
     libgl1-mesa-dev libgles2-mesa-dev libegl1-mesa-dev libdrm-dev libgbm-dev fonts-liberation fontconfig libsystemd-dev libinput-dev libudev-dev libxkbcommon-dev libseat-dev \
-    libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libgstreamer-plugins-bad1.0-dev gstreamer1.0-plugins-base gstreamer1.0-plugins-good gstreamer1.0-plugins-ugly gstreamer1.0-plugins-bad gstreamer1.0-libav gstreamer1.0-alsa
+    libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libgstreamer-plugins-bad1.0-dev gstreamer1.0-plugins-base gstreamer1.0-plugins-good gstreamer1.0-plugins-ugly gstreamer1.0-plugins-bad gstreamer1.0-libav gstreamer1.0-alsa \
+    libepoxy-dev
+
+USER 1000:1000
+WORKDIR /home/vscode
+
+ARG FLUTTER_VERSION=3.22.1
+RUN env DEBIAN_FRONTEND=noninteractive \
+    git clone -b $FLUTTER_VERSION https://github.com/flutter/flutter.git
+ENV PATH "/home/vscode/flutter/bin:$PATH"
+
+RUN flutter doctor
+
+USER root

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -207,6 +207,7 @@ if (ENABLE_OPENGL)
   if (EGL_FOUND AND GLES2_FOUND)
     target_sources(flutterpi_module PRIVATE
       src/egl_gbm_render_surface.c
+      src/egl_offscreen_render_surface.c
       src/gl_renderer.c
     )
     target_link_libraries(flutterpi_module PUBLIC

--- a/src/egl_offscreen_render_surface.c
+++ b/src/egl_offscreen_render_surface.c
@@ -1,0 +1,333 @@
+// SPDX-License-Identifier: MIT
+/*
+ * GBM Surface Backing Stores
+ *
+ * - implements EGL/GL render surfaces using a gbm surface
+ * - ideal way to create render surfaces right now
+ *
+ * Copyright (c) 2022, Hannes Winkler <hanneswinkler2000@web.de>
+ */
+
+#include "egl_offscreen_render_surface.h"
+
+#include <errno.h>
+#include <stdlib.h>
+
+#include "egl.h"
+#include "gl_renderer.h"
+#include "gles.h"
+#include "modesetting.h"
+#include "pixel_format.h"
+#include "render_surface.h"
+#include "render_surface_private.h"
+#include "surface.h"
+#include "tracer.h"
+#include "util/collection.h"
+#include "util/logging.h"
+#include "util/refcounting.h"
+
+struct egl_offscreen_render_surface;
+
+struct egl_offscreen_render_surface {
+    union {
+        struct surface surface;
+        struct render_surface render_surface;
+    };
+
+#ifdef DEBUG
+    uuid_t uuid;
+#endif
+
+    enum pixfmt pixel_format;
+    EGLDisplay egl_display;
+    EGLSurface egl_surface;
+    EGLConfig egl_config;
+    struct gl_renderer *renderer;
+};
+
+COMPILE_ASSERT(offsetof(struct egl_offscreen_render_surface, surface) == 0);
+COMPILE_ASSERT(offsetof(struct egl_offscreen_render_surface, render_surface.surface) == 0);
+
+#ifdef DEBUG
+static const uuid_t uuid = CONST_UUID(0xf9, 0xab, 0x5d, 0xad, 0x2e, 0x3b, 0x4e, 0x2c, 0x9d, 0x26, 0x64, 0x70, 0xfa, 0x9a, 0x25, 0xab);
+#endif
+
+#define CAST_THIS(ptr) CAST_EGL_OFFSCREEN_RENDER_SURFACE(ptr)
+#define CAST_THIS_UNCHECKED(ptr) CAST_EGL_OFFSCREEN_RENDER_SURFACE_UNCHECKED(ptr)
+
+#ifdef DEBUG
+ATTR_PURE struct egl_offscreen_render_surface *__checked_cast_egl_offscreen_render_surface(void *ptr) {
+    struct egl_offscreen_render_surface *s;
+
+    s = CAST_EGL_OFFSCREEN_RENDER_SURFACE_UNCHECKED(ptr);
+    assert(uuid_equals(s->uuid, uuid));
+    return s;
+}
+#endif
+
+void egl_offscreen_render_surface_deinit(struct surface *s);
+static int egl_offscreen_render_surface_present_kms(struct surface *s, const struct fl_layer_props *props, struct kms_req_builder *builder);
+static int egl_offscreen_render_surface_present_fbdev(struct surface *s, const struct fl_layer_props *props, struct fbdev_commit_builder *builder);
+static int egl_offscreen_render_surface_fill(struct render_surface *s, FlutterBackingStore *fl_store);
+static int egl_offscreen_render_surface_queue_present(struct render_surface *s, const FlutterBackingStore *fl_store);
+
+static int egl_offscreen_render_surface_init(
+    struct egl_offscreen_render_surface *s,
+    struct tracer *tracer,
+    struct vec2i size,
+    struct gl_renderer *renderer,
+    enum pixfmt pixel_format,
+    EGLConfig egl_config
+) {
+    EGLDisplay egl_display;
+    EGLSurface egl_surface;
+    EGLBoolean egl_ok;
+    int ok;
+
+    ASSERT_NOT_NULL(renderer);
+    ASSUME_PIXFMT_VALID(pixel_format);
+    egl_display = gl_renderer_get_egl_display(renderer);
+    ASSERT_NOT_NULL(egl_display);
+
+#ifdef DEBUG
+    if (egl_config != EGL_NO_CONFIG_KHR) {
+        EGLint value = 0;
+
+        egl_ok = eglGetConfigAttrib(egl_display, egl_config, EGL_NATIVE_VISUAL_ID, &value);
+        if (egl_ok == EGL_FALSE) {
+            LOG_EGL_ERROR(eglGetError(), "Couldn't query pixel format of EGL framebuffer config. eglGetConfigAttrib");
+            return EIO;
+        }
+
+        ASSERT_EQUALS_MSG(
+            value,
+            get_pixfmt_info(pixel_format)->gbm_format,
+            "EGL framebuffer config pixel format doesn't match the argument pixel format."
+        );
+    }
+#endif
+
+    /// TODO: Think about allowing different tilings / modifiers here
+    if (egl_config == EGL_NO_CONFIG_KHR) {
+        // choose a config
+        egl_config = gl_renderer_choose_config_direct(renderer, pixel_format);
+        if (egl_config == EGL_NO_CONFIG_KHR) {
+            LOG_ERROR(
+                "EGL doesn't supported the specified pixel format %s. Try a different one (ARGB8888 should always work).\n",
+                get_pixfmt_info(pixel_format)->name
+            );
+            return EINVAL;
+        }
+    }
+
+// EGLAttribKHR is defined by EGL_KHR_cl_event2.
+#ifndef EGL_KHR_cl_event2
+    #error "EGL header definitions for extension EGL_KHR_cl_event2 are required."
+#endif
+
+    static const EGLAttribKHR surface_attribs[] = {
+        /* EGL_GL_COLORSPACE, GL_LINEAR / GL_SRGB */
+        /* EGL_RENDER_BUFFER, EGL_BACK_BUFFER / EGL_SINGLE_BUFFER */
+        /* EGL_VG_ALPHA_FORMAT, EGL_VG_ALPHA_FORMAT_NONPRE / EGL_VG_ALPHA_FORMAT_PRE */
+        /* EGL_VG_COLORSPACE, EGL_VG_COLORSPACE_sRGB / EGL_VG_COLORSPACE_LINEAR */
+        EGL_NONE,
+    };
+
+    (void) surface_attribs;
+
+    egl_ok = eglBindAPI(EGL_OPENGL_ES_API);
+    if (egl_ok == EGL_FALSE) {
+        LOG_EGL_ERROR(eglGetError(), "Couldn't bind OpenGL ES API to EGL. eglBindAPI");
+        return EIO;
+    }
+
+    egl_surface = gl_renderer_create_pbuffer_surface(renderer, egl_config, NULL, NULL);
+    if (egl_surface == EGL_NO_SURFACE) {
+        return EIO;
+    }
+
+    /// TODO: Implement
+    ok = render_surface_init(CAST_RENDER_SURFACE_UNCHECKED(s), tracer, size);
+    if (ok != 0) {
+        goto fail_destroy_egl_surface;
+    }
+
+    s->surface.present_kms = egl_offscreen_render_surface_present_kms;
+    s->surface.present_fbdev = egl_offscreen_render_surface_present_fbdev;
+    s->surface.deinit = egl_offscreen_render_surface_deinit;
+    s->render_surface.fill = egl_offscreen_render_surface_fill;
+    s->render_surface.queue_present = egl_offscreen_render_surface_queue_present;
+#ifdef DEBUG
+    uuid_copy(&s->uuid, uuid);
+#endif
+    s->pixel_format = pixel_format;
+    s->egl_display = egl_display;
+    s->egl_surface = egl_surface;
+    s->egl_config = egl_config;
+    s->renderer = gl_renderer_ref(renderer);
+    return 0;
+
+fail_destroy_egl_surface:
+    eglDestroySurface(egl_display, egl_surface);
+
+    return ok;
+}
+
+/**
+ * @brief Create a new gbm_surface based render surface, with an explicit EGL Config for the created EGLSurface.
+ *
+ * @param compositor The compositor that this surface will be registered to when calling surface_register.
+ * @param size The size of the surface.
+ * @param renderer The EGL/OpenGL used to create any GL surfaces.
+ * @param pixel_format The pixel format to be used by the framebuffers of the surface.
+ * @param egl_config The EGLConfig used for creating the EGLSurface.
+ * @param allowed_modifiers The list of modifiers that gbm_surface_create_with_modifiers can choose from.
+ *                          NULL if not specified. (In that case, gbm_surface_create will be used)
+ * @param n_allowed_modifiers The number of modifiers in @param allowed_modifiers.
+ * @return struct egl_offscreen_render_surface*
+ */
+struct egl_offscreen_render_surface *egl_offscreen_render_surface_new_with_egl_config(
+    struct tracer *tracer,
+    struct vec2i size,
+    struct gl_renderer *renderer,
+    enum pixfmt pixel_format,
+    EGLConfig egl_config
+) {
+    struct egl_offscreen_render_surface *surface;
+    int ok;
+
+    surface = malloc(sizeof *surface);
+    if (surface == NULL) {
+        goto fail_return_null;
+    }
+
+    ok = egl_offscreen_render_surface_init(
+        surface,
+        tracer,
+        size,
+        renderer,
+        pixel_format,
+        egl_config
+    );
+    if (ok != 0) {
+        goto fail_free_surface;
+    }
+
+    return surface;
+
+fail_free_surface:
+    free(surface);
+
+fail_return_null:
+    return NULL;
+}
+
+/**
+ * @brief Create a new gbm_surface based render surface.
+ *
+ * @param compositor The compositor that this surface will be registered to when calling surface_register.
+ * @param size The size of the surface.
+ * @param device The GBM device used to allocate the surface.
+ * @param renderer The EGL/OpenGL used to create any GL surfaces.
+ * @param pixel_format The pixel format to be used by the framebuffers of the surface.
+ * @return struct egl_offscreen_render_surface*
+ */
+struct egl_offscreen_render_surface *egl_offscreen_render_surface_new(
+    struct tracer *tracer,
+    struct vec2i size,
+    struct gl_renderer *renderer,
+    enum pixfmt pixel_format
+) {
+    return egl_offscreen_render_surface_new_with_egl_config(tracer, size, renderer, pixel_format, EGL_NO_CONFIG_KHR);
+}
+
+void egl_offscreen_render_surface_deinit(struct surface *s) {
+    struct egl_offscreen_render_surface *egl_surface;
+
+    egl_surface = CAST_THIS(s);
+
+    gl_renderer_unref(egl_surface->renderer);
+    render_surface_deinit(s);
+}
+
+static int egl_offscreen_render_surface_present_kms(struct surface *s, const struct fl_layer_props *props, struct kms_req_builder *builder) {
+    (void) s;
+    (void) props;
+    (void) builder;
+
+    UNIMPLEMENTED();
+
+    return 0;
+}
+
+static int
+egl_offscreen_render_surface_present_fbdev(struct surface *s, const struct fl_layer_props *props, struct fbdev_commit_builder *builder) {
+    struct egl_offscreen_render_surface *egl_surface;
+
+    /// TODO: Implement by mmapping the current front bo, copy it into the fbdev
+    /// TODO: Print a warning here if we're not using explicit linear tiling and use glReadPixels instead of gbm_bo_map in that case
+
+    egl_surface = CAST_THIS(s);
+    (void) egl_surface;
+    (void) props;
+    (void) builder;
+
+    UNIMPLEMENTED();
+
+    return 0;
+}
+
+static int egl_offscreen_render_surface_fill(struct render_surface *s, FlutterBackingStore *fl_store) {
+    fl_store->type = kFlutterBackingStoreTypeOpenGL;
+    fl_store->open_gl = (FlutterOpenGLBackingStore
+    ){ .type = kFlutterOpenGLTargetTypeFramebuffer,
+       .framebuffer = { /* for some reason flutter wants this to be GL_BGRA8_EXT, contrary to what the docs say */
+                        .target = GL_BGRA8_EXT,
+
+                        /* 0 refers to the window surface, instead of to an FBO */
+                        .name = 0,
+
+                        /*
+             * even though the compositor will call surface_ref too to fill the FlutterBackingStore.user_data,
+             * we need to ref two times because flutter will call both this destruction callback and the
+             * compositor collect callback
+             */
+                        .user_data = surface_ref(CAST_SURFACE_UNCHECKED(s)),
+                        .destruction_callback = surface_unref_void } };
+    return 0;
+}
+
+static int egl_offscreen_render_surface_queue_present(struct render_surface *s, const FlutterBackingStore *fl_store) {
+    (void) s;
+    (void) fl_store;
+    
+    // nothing to do here
+    
+    return 0;
+}
+
+/**
+ * @brief Get the EGL Surface for rendering into this render surface.
+ *
+ * Flutter doesn't really support backing stores to be EGL Surfaces, so we have to hack around this, kinda.
+ *
+ * @param s
+ * @return EGLSurface The EGLSurface associated with this render surface. Only valid for the lifetime of this egl_offscreen_render_surface.
+ */
+ATTR_PURE EGLSurface egl_offscreen_render_surface_get_egl_surface(struct egl_offscreen_render_surface *s) {
+    return s->egl_surface;
+}
+
+/**
+ * @brief Get the EGLConfig that was used to create the EGLSurface for this render surface.
+ *
+ * If the display doesn't support EGL_KHR_no_config_context, we need to create the EGL rendering context with
+ * the same EGLConfig as every EGLSurface we want to bind to it. So we can just let egl_offscreen_render_surface choose a config
+ * and let flutter-pi query that config when creating the rendering contexts in that case.
+ *
+ * @param s
+ * @return EGLConfig The chosen EGLConfig. Valid forever.
+ */
+ATTR_PURE EGLConfig egl_offscreen_render_surface_get_egl_config(struct egl_offscreen_render_surface *s) {
+    return s->egl_config;
+}

--- a/src/egl_offscreen_render_surface.h
+++ b/src/egl_offscreen_render_surface.h
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: MIT
+/*
+ * Offscreen (MESA surfaceless) backing store
+ *
+ * Copyright (c) 2022, Hannes Winkler <hanneswinkler2000@web.de>
+ */
+
+#ifndef _FLUTTERPI_SRC_EGL_OFFSCREEN_RENDER_SURFACE_H
+#define _FLUTTERPI_SRC_EGL_OFFSCREEN_RENDER_SURFACE_H
+
+#include "compositor_ng.h"
+#include "pixel_format.h"
+#include "util/collection.h"
+
+struct render_surface;
+struct gbm_device;
+struct egl_offscreen_render_surface;
+
+#define CAST_EGL_OFFSCREEN_RENDER_SURFACE_UNCHECKED(ptr) ((struct egl_offscreen_render_surface *) (ptr))
+#ifdef DEBUG
+    #define CAST_EGL_OFFSCREEN_RENDER_SURFACE(ptr) __checked_cast_egl_offscreen_render_surface(ptr)
+ATTR_PURE struct egl_offscreen_render_surface *__checked_cast_egl_offscreen_render_surface(void *ptr);
+#else
+    #define CAST_EGL_OFFSCREEN_RENDER_SURFACE(ptr) CAST_EGL_OFFSCREEN_RENDER_SURFACE_UNCHECKED(ptr)
+#endif
+
+struct egl_offscreen_render_surface *egl_offscreen_render_surface_new_with_egl_config(
+    struct tracer *tracer,
+    struct vec2i size,
+    struct gl_renderer *renderer,
+    enum pixfmt pixel_format,
+    EGLConfig egl_config
+);
+
+struct egl_offscreen_render_surface *egl_offscreen_render_surface_new(
+    struct tracer *tracer,
+    struct vec2i size,
+    struct gl_renderer *renderer,
+    enum pixfmt pixel_format
+);
+
+ATTR_PURE EGLSurface egl_offscreen_render_surface_get_egl_surface(struct egl_offscreen_render_surface *s);
+
+ATTR_PURE EGLConfig egl_offscreen_render_surface_get_egl_config(struct egl_offscreen_render_surface *s);
+
+#endif  // _FLUTTERPI_SRC_EGL_GBM_RENDER_SURFACE_H

--- a/src/flutter-pi.c
+++ b/src/flutter-pi.c
@@ -2165,14 +2165,14 @@ fail_free_devices:
     return NULL;
 }
 
-static struct gbm_device *open_rendernode_as_gbm_device() {
+UNUSED static struct gbm_device *try_open_rendernode_as_gbm_device() {
     struct gbm_device *gbm;
     drmDevicePtr devices[64];
     int ok, n_devices;
 
     ok = drmGetDevices2(0, devices, sizeof(devices) / sizeof(*devices));
     if (ok < 0) {
-        LOG_ERROR("Could not query DRM device list: %s\n", strerror(-ok));
+        LOG_DEBUG("Could not find a usable GPU, couldn't query GPU device list: drmGetDevices2: %s\n", strerror(-ok));
         return NULL;
     }
 
@@ -2209,10 +2209,7 @@ static struct gbm_device *open_rendernode_as_gbm_device() {
     drmFreeDevices(devices, n_devices);
 
     if (gbm == NULL) {
-        LOG_ERROR(
-            "flutter-pi couldn't find a usable render device.\n"
-            "Please make sure you have a GPU connected.\n"
-        );
+        LOG_DEBUG("Could not find a usable GPU.\n");
         return NULL;
     }
 
@@ -2442,10 +2439,7 @@ struct flutterpi *flutterpi_new_from_args(int argc, char **argv) {
         // render node as a GBM device.
         // There's other ways to get an offscreen EGL display, but we need the gbm_device for other things
         // (e.g. buffer allocating for the video player, so we just do this.)
-        gbm_device = open_rendernode_as_gbm_device();
-        if (gbm_device == NULL) {
-            goto fail_destroy_locales;
-        }
+        gbm_device = try_open_rendernode_as_gbm_device();
     } else {
         drmdev = find_drmdev(libseat);
         if (drmdev == NULL) {
@@ -2486,11 +2480,21 @@ struct flutterpi *flutterpi_new_from_args(int argc, char **argv) {
     } else if (renderer_type == kOpenGL_RendererType) {
 #ifdef HAVE_EGL_GLES2
         vk_renderer = NULL;
-        gl_renderer = gl_renderer_new_from_gbm_device(tracer, gbm_device, cmd_args.has_pixel_format, cmd_args.pixel_format);
-        if (gl_renderer == NULL) {
-            LOG_ERROR("Couldn't create EGL/OpenGL renderer.\n");
-            ok = EIO;
-            goto fail_unref_scheduler;
+
+        if (gbm_device != NULL) {
+            gl_renderer = gl_renderer_new_from_gbm_device(tracer, gbm_device, cmd_args.has_pixel_format, cmd_args.pixel_format);
+            if (gl_renderer == NULL) {
+                LOG_ERROR("Couldn't create EGL/OpenGL renderer.\n");
+                ok = EIO;
+                goto fail_unref_scheduler;
+            }
+        } else {
+            gl_renderer = gl_renderer_new_surfaceless(tracer, cmd_args.has_pixel_format, cmd_args.pixel_format);
+            if (gl_renderer == NULL) {
+                LOG_ERROR("Couldn't create EGL/OpenGL renderer.\n");
+                ok = EIO;
+                goto fail_unref_scheduler;
+            }
         }
 
         // it seems that after some Raspbian update, regular users are sometimes no longer allowed

--- a/src/gl_renderer.c
+++ b/src/gl_renderer.c
@@ -442,11 +442,7 @@ fail_return_null:
     return NULL;
 }
 
-struct gl_renderer *gl_renderer_new_surfaceless(
-    struct tracer *tracer,
-    bool has_forced_pixel_format,
-    enum pixfmt pixel_format
-) {
+struct gl_renderer *gl_renderer_new_surfaceless(struct tracer *tracer, bool has_forced_pixel_format, enum pixfmt pixel_format) {
     struct gl_renderer *renderer;
     const char *egl_client_exts, *egl_display_exts;
     const char *gl_renderer, *gl_exts;
@@ -492,7 +488,6 @@ struct gl_renderer *gl_renderer_new_surfaceless(
 // are defined by EGL_EXT_platform_base.
 #ifdef EGL_EXT_platform_base
     PFNEGLGETPLATFORMDISPLAYEXTPROC egl_get_platform_display_ext;
-    PFNEGLCREATEPLATFORMWINDOWSURFACEEXTPROC egl_create_platform_window_surface_ext;
 #endif
 
     if (supports_egl_ext_platform_base) {
@@ -506,26 +501,6 @@ struct gl_renderer *gl_renderer_new_surfaceless(
         UNREACHABLE();
 #endif
     }
-
-    if (supports_egl_ext_platform_base) {
-#ifdef EGL_EXT_platform_base
-        egl_create_platform_window_surface_ext = try_get_proc_address("eglCreatePlatformWindowSurfaceEXT");
-        if (egl_create_platform_window_surface_ext == NULL) {
-            LOG_ERROR(
-                "Couldn't resolve \"eglCreatePlatformWindowSurfaceEXT\" even though \"EGL_EXT_platform_base\" was listed as supported.\n"
-            );
-            egl_get_platform_display_ext = NULL;
-            supports_egl_ext_platform_base = false;
-        }
-#else
-        UNREACHABLE();
-#endif
-    }
-
-// EGL_PLATFORM_GBM_KHR is defined by EGL_KHR_platform_gbm.
-#ifndef EGL_KHR_platform_gbm
-    #error "EGL extension EGL_KHR_platform_gbm is required."
-#endif
 
     egl_display = EGL_NO_DISPLAY;
     bool failed_before = false;
@@ -574,7 +549,7 @@ struct gl_renderer *gl_renderer_new_surfaceless(
 
     egl_ok = eglInitialize(egl_display, &major, &minor);
     if (egl_ok != EGL_TRUE) {
-        LOG_EGL_ERROR(eglGetError(), "Failed to initialize EGL! eglInitialize:");
+        LOG_EGL_ERROR(eglGetError(), "Failed to initialize EGL! eglInitialize");
         goto fail_free_renderer;
     }
 
@@ -722,7 +697,7 @@ struct gl_renderer *gl_renderer_new_surfaceless(
     renderer->supports_egl_ext_platform_base = supports_egl_ext_platform_base;
 #ifdef EGL_EXT_platform_base
     renderer->egl_get_platform_display_ext = egl_get_platform_display_ext;
-    renderer->egl_create_platform_window_surface_ext = egl_create_platform_window_surface_ext;
+    renderer->egl_create_platform_window_surface_ext = NULL;
 #endif
 #ifdef EGL_VERSION_1_5
     renderer->egl_get_platform_display = egl_get_platform_display;
@@ -754,7 +729,6 @@ fail_free_renderer:
 fail_return_null:
     return NULL;
 }
-
 
 void gl_renderer_destroy(struct gl_renderer *renderer) {
     ASSERT_NOT_NULL(renderer);

--- a/src/gl_renderer.h
+++ b/src/gl_renderer.h
@@ -35,6 +35,12 @@ struct gl_renderer *gl_renderer_new_from_gbm_device(
     enum pixfmt pixel_format
 );
 
+struct gl_renderer *gl_renderer_new_surfaceless(
+    struct tracer *tracer,
+    bool has_forced_pixel_format,
+    enum pixfmt pixel_format
+);
+
 void gl_renderer_destroy(struct gl_renderer *renderer);
 
 DECLARE_REF_OPS(gl_renderer)
@@ -81,6 +87,13 @@ EGLSurface gl_renderer_create_gbm_window_surface(
     struct gl_renderer *renderer,
     EGLConfig config,
     struct gbm_surface *gbm_surface,
+    const EGLAttribKHR *attrib_list,
+    const EGLint *int_attrib_list
+);
+
+EGLSurface gl_renderer_create_pbuffer_surface(
+    struct gl_renderer *renderer,
+    EGLConfig config,
     const EGLAttribKHR *attrib_list,
     const EGLint *int_attrib_list
 );

--- a/src/window.c
+++ b/src/window.c
@@ -33,6 +33,7 @@
 
 #ifdef HAVE_EGL_GLES2
     #include "egl_gbm_render_surface.h"
+    #include "egl_offscreen_render_surface.h"
     #include "gl_renderer.h"
 #endif
 
@@ -943,9 +944,8 @@ MUST_CHECK struct window *kms_window_new(
         has_dimensions = true;
         width_mm = selected_connector->variable_state.width_mm;
         height_mm = selected_connector->variable_state.height_mm;
-    } else if (selected_connector->type == DRM_MODE_CONNECTOR_DSI
-        && selected_connector->variable_state.width_mm == 0
-        && selected_connector->variable_state.height_mm == 0) {
+    } else if (selected_connector->type == DRM_MODE_CONNECTOR_DSI && selected_connector->variable_state.width_mm == 0 &&
+               selected_connector->variable_state.height_mm == 0) {
         // assume this is the official Raspberry Pi DSI display.
         has_dimensions = true;
         width_mm = 155;
@@ -1693,22 +1693,38 @@ static struct render_surface *dummy_window_get_render_surface_internal(struct wi
     #ifndef EGL_KHR_no_config_context
         #error "EGL header definitions for extension EGL_KHR_no_config_context are required."
     #endif
+        struct gbm_device *gbm_device = gl_renderer_get_gbm_device(window->gl_renderer);
 
-        struct egl_gbm_render_surface *egl_surface = egl_gbm_render_surface_new_with_egl_config(
-            window->tracer,
-            size,
-            gl_renderer_get_gbm_device(window->gl_renderer),
-            window->gl_renderer,
-            window->has_forced_pixel_format ? window->forced_pixel_format : PIXFMT_ARGB8888,
-            EGL_NO_CONFIG_KHR,
-            NULL,
-            0
-        );
-        if (egl_surface == NULL) {
-            LOG_ERROR("Couldn't create EGL GBM rendering surface.\n");
-            render_surface = NULL;
+        if (gbm_device != NULL) {
+            struct egl_gbm_render_surface *egl_surface = egl_gbm_render_surface_new_with_egl_config(
+                window->tracer,
+                size,
+                gl_renderer_get_gbm_device(window->gl_renderer),
+                window->gl_renderer,
+                window->has_forced_pixel_format ? window->forced_pixel_format : PIXFMT_ARGB8888,
+                EGL_NO_CONFIG_KHR,
+                NULL,
+                0
+            );
+            if (egl_surface == NULL) {
+                LOG_ERROR("Couldn't create EGL GBM rendering surface.\n");
+                render_surface = NULL;
+            } else {
+                render_surface = CAST_RENDER_SURFACE(egl_surface);
+            }
         } else {
-            render_surface = CAST_RENDER_SURFACE(egl_surface);
+            struct egl_offscreen_render_surface *egl_surface = egl_offscreen_render_surface_new(
+                window->tracer,
+                size,
+                window->gl_renderer,
+                window->has_forced_pixel_format ? window->forced_pixel_format : PIXFMT_ARGB8888
+            );
+            if (egl_surface == NULL) {
+                LOG_ERROR("Couldn't create EGL offscreen rendering surface.\n");
+                render_surface = NULL;
+            } else {
+                render_surface = CAST_RENDER_SURFACE(egl_surface);
+            }
         }
 
 #else


### PR DESCRIPTION
- **add offscreen (MESA_platform_surfaceless) rendering surface**
- use that in case there's no hardware GPU present
- **refactor egl config selection**
- necessary for creating complete offscreen surfaces (pbuffer surfaces)

- offscreen rendering is useful for CI tests

