### PR TITLE
fix: assign message to platform message

### DIFF
--- a/src/flutter-pi.c
+++ b/src/flutter-pi.c
@@ -815,6 +815,7 @@ static int on_send_platform_message(void *userdata) {
         message.channel = msg->target_channel;
         message.message_size = msg->message_size;
         message.response_handle = msg->response_handle;
+        message.message = msg->message;
 
         result = flutterpi->flutter.procs.SendPlatformMessage(flutterpi->flutter.engine, &message);
     }


### PR DESCRIPTION
I am not sure whether this is correct because I have only skimmed the code, but assigning the message fixed the gstreamer-video-player camera in release mode for me.