### PR TITLE
Add --drm-vout-display Parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,6 +382,9 @@ OPTIONS:
   --dummy-display-size "width,height" The width & height of the dummy display
                              in pixels.
 
+  --drm-vout-display <drm-device>  The DRM display to use.\n\
+                             HDMI-A-1, HDMI-A-2, DSI-1, DSI-2.\n\
+
   -h, --help                 Show this help and exit.
 
 EXAMPLES:

--- a/README.md
+++ b/README.md
@@ -382,7 +382,7 @@ OPTIONS:
   --dummy-display-size "width,height" The width & height of the dummy display
                              in pixels.
 
-  --drm-vout-display <drm-device>  The DRM display to use.\n\
+  --display <device>         The display to use.\n\
                              HDMI-A-1, HDMI-A-2, DSI-1, DSI-2.\n\
 
   -h, --help                 Show this help and exit.

--- a/src/flutter-pi.c
+++ b/src/flutter-pi.c
@@ -141,6 +141,8 @@ OPTIONS:\n\
                              without a display attached.\n\
   --dummy-display-size \"width,height\" The width & height of the dummy display\n\
                              in pixels.\n\
+  --drm-vout-display <drm-device>  The DRM display to use.\n\
+                             HDMI-A-1, HDMI-A-2, DSI-1, DSI-2.\n\
 \n\
   -h, --help                 Show this help and exit.\n\
 \n\
@@ -262,6 +264,8 @@ struct flutterpi {
     bool session_active;
 
     char *desired_videomode;
+
+    char *drm_vout_display;
 };
 
 struct device_id_and_fd {
@@ -1853,6 +1857,16 @@ static bool parse_vec2i(const char *str, struct vec2i *out) {
     return true;
 }
 
+bool is_valid_drm_display(const char *display) {
+    const char *valid_displays[] = { "HDMI-A-1", "HDMI-A-2", "DSI-1", "DSI-2" };
+    for (size_t i = 0; i < sizeof(valid_displays) / sizeof(valid_displays[0]); i++) {
+        if (strcmp(display, valid_displays[i]) == 0) {
+            return true;
+        }
+    }
+    return false;
+}
+
 bool flutterpi_parse_cmdline_args(int argc, char **argv, struct flutterpi_cmdline_args *result_out) {
     bool finished_parsing_options;
     int runtime_mode_int = FLUTTER_RUNTIME_MODE_DEBUG;
@@ -1876,6 +1890,7 @@ bool flutterpi_parse_cmdline_args(int argc, char **argv, struct flutterpi_cmdlin
         { "videomode", required_argument, NULL, 'v' },
         { "dummy-display", no_argument, &dummy_display_int, 1 },
         { "dummy-display-size", required_argument, NULL, 's' },
+        { "drm-vout-display", required_argument, NULL, 'i' },
         { 0, 0, 0, 0 },
     };
 
@@ -1997,6 +2012,17 @@ valid_format:
 
                 break;
 
+            case 'i':  // --drm-vout-display
+                result_out->drm_vout_display = strdup(optarg);
+                if (result_out->drm_vout_display == NULL) {
+                    return false;
+                }
+                if (!is_valid_drm_display(result_out->drm_vout_display)) {
+                    LOG_ERROR("Invalid DRM display specified: %s. Valid options are HDMI-A-1, HDMI-A-2, DSI-1, DSI-2.\n", optarg);
+                    return false;
+                }
+                break;
+
             case 'h': printf("%s", usage); return false;
 
             case '?':
@@ -2099,6 +2125,25 @@ static void on_drmdev_close(int fd, void *fd_metadata, void *userdata) {
 
 static const struct drmdev_interface drmdev_interface = { .open = on_drmdev_open, .close = on_drmdev_close };
 
+bool parse_drm_vout_display(const char *display, int *type_out, int *type_id_out) {
+    if (strcmp(display, "HDMI-A-1") == 0) {
+        *type_out = DRM_MODE_CONNECTOR_HDMIA;
+        *type_id_out = 1;
+    } else if (strcmp(display, "HDMI-A-2") == 0) {
+        *type_out = DRM_MODE_CONNECTOR_HDMIA;
+        *type_id_out = 2;
+    } else if (strcmp(display, "DSI-1") == 0) {
+        *type_out = DRM_MODE_CONNECTOR_DSI;
+        *type_id_out = 1;
+    } else if (strcmp(display, "DSI-2") == 0) {
+        *type_out = DRM_MODE_CONNECTOR_DSI;
+        *type_id_out = 2;
+    } else {
+        return false;
+    }
+    return true;
+}
+
 static struct drmdev *find_drmdev(struct libseat *libseat) {
     struct drm_connector *connector;
     struct drmdev *drmdev;
@@ -2137,7 +2182,21 @@ static struct drmdev *find_drmdev(struct libseat *libseat) {
 
         for_each_connector_in_drmdev(drmdev, connector) {
             if (connector->variable_state.connection_state == kConnected_DrmConnectionState) {
-                goto found_connected_connector;
+                if (flutterpi->drm_vout_display != NULL) {
+                    // We only want to use the display that was specified on the command line.
+                    int expected_type, expected_type_id;
+                    if (!parse_drm_vout_display(flutterpi->drm_vout_display, &expected_type, &expected_type_id)) {
+                        continue;
+                    }
+
+                    if (connector->type == expected_type && connector->type_id == expected_type_id) {
+                        goto found_connected_connector;
+                    } else {
+                        continue; 
+                    }
+                } else {
+                    goto found_connected_connector;
+                }
             }
         }
         LOG_ERROR("Device \"%s\" doesn't have a display connected. Skipping.\n", device->nodes[DRM_NODE_PRIMARY]);
@@ -2334,6 +2393,8 @@ struct flutterpi *flutterpi_new_from_args(int argc, char **argv) {
     if (ok == false) {
         goto fail_free_fpi;
     }
+
+    fpi->drm_vout_display = cmd_args.drm_vout_display ? strdup(cmd_args.drm_vout_display) : NULL;
 
 #ifndef HAVE_VULKAN
     if (cmd_args.use_vulkan == true) {

--- a/src/flutter-pi.c
+++ b/src/flutter-pi.c
@@ -141,7 +141,7 @@ OPTIONS:\n\
                              without a display attached.\n\
   --dummy-display-size \"width,height\" The width & height of the dummy display\n\
                              in pixels.\n\
-  --drm-vout-display <drm-device>  The DRM display to use.\n\
+  --display <device>         The display to use.\n\
                              HDMI-A-1, HDMI-A-2, DSI-1, DSI-2.\n\
 \n\
   -h, --help                 Show this help and exit.\n\
@@ -1890,7 +1890,7 @@ bool flutterpi_parse_cmdline_args(int argc, char **argv, struct flutterpi_cmdlin
         { "videomode", required_argument, NULL, 'v' },
         { "dummy-display", no_argument, &dummy_display_int, 1 },
         { "dummy-display-size", required_argument, NULL, 's' },
-        { "drm-vout-display", required_argument, NULL, 'i' },
+        { "display", required_argument, NULL, 'i' },
         { 0, 0, 0, 0 },
     };
 
@@ -2012,13 +2012,13 @@ valid_format:
 
                 break;
 
-            case 'i':  // --drm-vout-display
+            case 'i':  // --display
                 result_out->drm_vout_display = strdup(optarg);
                 if (result_out->drm_vout_display == NULL) {
                     return false;
                 }
                 if (!is_valid_drm_display(result_out->drm_vout_display)) {
-                    LOG_ERROR("Invalid DRM display specified: %s. Valid options are HDMI-A-1, HDMI-A-2, DSI-1, DSI-2.\n", optarg);
+                    LOG_ERROR("Invalid display specified: %s. Valid options are HDMI-A-1, HDMI-A-2, DSI-1, DSI-2.\n", optarg);
                     return false;
                 }
                 break;

--- a/src/flutter-pi.h
+++ b/src/flutter-pi.h
@@ -141,6 +141,8 @@ struct flutterpi_cmdline_args {
 
     bool dummy_display;
     struct vec2i dummy_display_size;
+
+    char *drm_vout_display;
 };
 
 int flutterpi_fill_view_properties(bool has_orientation, enum device_orientation orientation, bool has_rotation, int rotation);


### PR DESCRIPTION
## Add `--drm-vout-display` Parameter for Selecting Specific DRM Outputs

This pull request introduces a new command-line parameter, `--drm-vout-display`, to allow users to specify the desired DRM output display when running Flutter applications on Raspberry Pi. 

This change is implemented in response to [issue #201](https://github.com/ardera/flutter-pi/issues/201).

### Supported Options
The supported values for this parameter are:
- `HDMI-A-1`
- `HDMI-A-2`
- `DSI-1`
- `DSI-2`

If the `--drm-vout-display` parameter is not provided, the code will behave as before, automatically selecting the first available connected display.

---

### Key Changes

#### New Command-Line Argument
- Added the `--drm-vout-display` option to the command-line arguments.
- Users can now specify the desired display output by providing one of the supported values.

#### Validation and Parsing
- The provided value is validated against the supported options (`HDMI-A-1`, `HDMI-A-2`, `DSI-1`, `DSI-2`).
- The `flutterpi` struct now includes a `drm_vout_display` field to store the selected display.

#### Behavior
- If a valid display is specified, the code will attempt to use the corresponding DRM connector type and type ID.
- If no display is specified, the code defaults to the previous behavior of selecting the first available connected display.

#### Documentation
- Updated the `--help` output to include the new `--drm-vout-display` option.
- The supported values are based on the Raspberry Pi documentation: **Playing Audio and Video**.

---

### Example Usage
```sh
flutter-pi --drm-vout-display HDMI-A-1
```

---

### Backward Compatibility
This change is fully backward-compatible. If the `--drm-vout-display` parameter is not provided, the application will function as it did previously, automatically selecting the first available connected display.

---

### Motivation
This feature provides users with greater control over which display output is used, especially in multi-display setups or when specific outputs are required for certain use cases.
