### PR TITLE
[MVP/WIP] add support kms drm property set

### DIFF
--- a/src/flutter-pi.c
+++ b/src/flutter-pi.c
@@ -2857,3 +2857,21 @@ int flutterpi_app_main(int argc, char **argv) {
 
     return EXIT_SUCCESS;
 }
+
+
+
+uint32_t KMS_DRM_isAvailable() {
+    // if (plugin!= NULL && plugin->flutterpi->drmdev != NULL) {
+    if (flutterpi->drmdev != NULL) {
+        return 1;
+    }
+    return 0;
+}
+
+void KMS_DRM_setProperty(uint32_t propId, uint64_t value) {
+    kms_drm_setProperty(flutterpi->drmdev, propId, value);
+}
+
+uint64_t KMS_DRM_getProperty(uint32_t propId) {
+    return -1;
+}

--- a/src/flutter-pi.h
+++ b/src/flutter-pi.h
@@ -196,4 +196,10 @@ void flutterpi_trace_event_begin(struct flutterpi *flutterpi, const char *name);
 
 void flutterpi_trace_event_end(struct flutterpi *flutterpi, const char *name);
 
+uint32_t KMS_DRM_isAvailable();
+
+void KMS_DRM_setProperty(uint32_t propId, uint64_t value) ;
+
+uint64_t KMS_DRM_getProperty(uint32_t propId);
+
 #endif  // _FLUTTERPI_SRC_FLUTTERPI_H

--- a/src/modesetting.c
+++ b/src/modesetting.c
@@ -2990,3 +2990,16 @@ int kms_req_commit_blocking(struct kms_req *req, uint64_t *vblank_ns_out) {
 int kms_req_commit_nonblocking(struct kms_req *req, kms_scanout_cb_t scanout_cb, void *userdata, void_callback_t destroy_cb) {
     return kms_req_commit_common(req, false, scanout_cb, userdata, destroy_cb);
 }
+
+
+void kms_drm_setProperty(struct drmdev *drmdev, uint32_t propId, uint64_t value){
+    struct drm_connector *connectors =  drmdev->connectors;
+    size_t n_connectors = drmdev->n_connectors;
+    for (int i = 0; i < n_connectors; i++) {
+        if (
+        connectors->variable_state.connection_state == kConnected_DrmConnectionState ||
+        connectors->variable_state.connection_state == kUnknown_DrmConnectionState ){
+            drmModeObjectSetProperty(drmdev->fd, connectors->id, DRM_MODE_OBJECT_CONNECTOR, propId, value);
+        }
+    }
+}

--- a/src/modesetting.h
+++ b/src/modesetting.h
@@ -918,6 +918,8 @@ int kms_req_commit_blocking(struct kms_req *req, uint64_t *vblank_ns_out);
 
 int kms_req_commit_nonblocking(struct kms_req *req, kms_scanout_cb_t scanout_cb, void *userdata, void_callback_t destroy_cb);
 
+void kms_drm_setProperty(struct drmdev *drmdev, uint32_t propId, uint64_t value);
+
 struct drm_connector *__next_connector(const struct drmdev *drmdev, const struct drm_connector *connector);
 
 struct drm_encoder *__next_encoder(const struct drmdev *drmdev, const struct drm_encoder *encoder);


### PR DESCRIPTION
I added kms drm property set function.
The code is dirty, but it works.
Any suggestions for improvement?

It allows turn off/on screen.

For my case I use HDMI-0.
`kmsprint -p `
show:
```
Connector 0 (33) HDMI-A-1 (connected)
    EDID (1) = blob-id 678 len 256 (immutable)
    DPMS (2) = 0 (On) [On=0|Standby=1|Suspend=2|Off=3]
    TILE (4) = blob-id 0 (immutable)
    link-status (5) = 0 (Good) [Good=0|Bad=1]
```

Screen ON:
```
if (kmsDrmService.isAvailable()) {
  // DPMS (2) = 3 (Off) [On=0|Standby=1|Suspend=2|Off=3]
  kmsDrmService.setProperty(2, 0);
}
```

Screen OFF:
```
if (kmsDrmService.isAvailable()) {
  // DPMS (2) = 0 (On) [On=0|Standby=1|Suspend=2|Off=3]
  kmsDrmService.setProperty(2, 3);
}
```

Service:
`  static final KmsDrmService kmsDrmService = KmsDrmService();`

```
/*
uint32_t KMS_DRM_isAvailable();

void KMS_DRM_setProperty(uint32_t propId, uint64_t value) ;

uint64_t KMS_DRM_getProperty(uint32_t propId);
*/

typedef KMS_DRM_setPropertyFuncType = ffi.Void Function(ffi.Uint32 propId, ffi.Uint64 value);
typedef KMS_DRM_setPropertyType = void Function(int propId, int value);

typedef KMS_DRM_isAvailableFuncType = ffi.Uint32 Function();
typedef KMS_DRM_isAvailableType = int Function();

class KmsDrmService {
  final _KmsDrmService _service = _KmsDrmService.instance;
  bool isAvailable() {
    if (_service.KMS_DRM_isAvailable == null || _service.KMS_DRM_isAvailable!() == 0) {
      return false;
    }
    return true;
  }

  void setProperty(int propId, int value) {
    if (_service.KMS_DRM_setProperty == null) {
      return;
    }
    _service.KMS_DRM_setProperty!(propId, value);
  }
}

class _KmsDrmService {
  final KMS_DRM_setPropertyType? KMS_DRM_setProperty;
  final KMS_DRM_isAvailableType? KMS_DRM_isAvailable;
  _KmsDrmService._constructor({required this.KMS_DRM_setProperty, required this.KMS_DRM_isAvailable});

  factory _KmsDrmService._() {
    final lib = ffi.DynamicLibrary.process();

    try {
      final KMS_DRM_setPropertyLFunc = lib.lookupFunction<KMS_DRM_setPropertyFuncType, KMS_DRM_setPropertyType>("KMS_DRM_setProperty");
      final KMS_DRM_isAvailableLFunc = lib.lookupFunction<KMS_DRM_isAvailableFuncType, KMS_DRM_isAvailableType>("KMS_DRM_isAvailable");

      return _KmsDrmService._constructor(
        KMS_DRM_setProperty: KMS_DRM_setPropertyLFunc,
        KMS_DRM_isAvailable: KMS_DRM_isAvailableLFunc,
      );
    } on ArgumentError {
      return _KmsDrmService._constructor(
        KMS_DRM_setProperty: null,
        KMS_DRM_isAvailable: null,
      );
    }
  }

  static _KmsDrmService? _instance;

  static _KmsDrmService get instance {
    if (_instance == null) {
      _instance = _KmsDrmService._();
    }

    return _instance!;
  }
}

```