### PR TITLE
feat(webview): add CEF powered webview plugin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,7 @@ option(LTO "Check for IPO/LTO support and enable, if supported. May require gold
 option(LINT_EGL_HEADERS "Set an define that'll make the egl.h only export the extension definitions, prototypes that are explicitly marked as required." OFF)
 option(DEBUG_DRM_PLANE_ALLOCATIONS "Add logging in modesetting.c for debugging the process of choosing a fitting DRM plane for a framebuffer layer." OFF)
 option(USE_LEGACY_KMS "Force the use of legacy KMS." OFF)
+option(BUILD_WEBVIEW_CEF_PLUGIN "Include Chromium Embedded Framework powered webview_cef plugin." OFF)
 
 # This is a CMake recognized variable, but we set it to off by default here.
 option(CMAKE_POSITION_INDEPENDENT_CODE "Enable/Disable Position Independent Code" OFF)
@@ -401,6 +402,81 @@ endif()
 message(STATUS "Sentry plugin .......... ${BUILD_SENTRY_PLUGIN}")
 message(STATUS "Bundle crashpad_handler  ${HAVE_BUNDLED_CRASHPAD_HANDLER}")
 
+if (BUILD_WEBVIEW_CEF_PLUGIN)
+  # CEF only ships a C++ API worth using; the rest of flutter-pi stays C.
+  enable_language(CXX)
+
+  # Where the CEF runtime files live *on the target*: libcef.so, icudtl.dat, the
+  # *.pak resource bundles, the v8 snapshot *.bin files and locales/.
+  # Chromium loads its bundled libEGL/libGLESv2 (ANGLE) and its resources from
+  # next to libcef.so, so it has to keep its own directory rather than being
+  # scattered into ${libdir}.
+  set(WEBVIEW_CEF_RUNTIME_DIR "/usr/lib/cef" CACHE PATH "Directory containing libcef.so and the CEF resources on the target.")
+  set(WEBVIEW_CEF_HELPER_PATH "/usr/bin/flutter-pi-cef-helper" CACHE FILEPATH "Path of the CEF subprocess helper on the target.")
+
+  # A CEF binary distribution, laid out so that ${CEF_ROOT}/include/cef_version.h,
+  # ${CEF_ROOT}/libcef.so and ${CEF_ROOT}/libcef_dll_wrapper.a exist.
+  # Leave empty to let CMake search the (cross) sysroot, which is what the yocto
+  # `cef` recipe populates.
+  set(CEF_ROOT "" CACHE PATH "Root of a CEF binary distribution.")
+
+  find_path(CEF_INCLUDE_DIR
+    NAMES include/cef_version.h
+    HINTS ${CEF_ROOT}
+    PATH_SUFFIXES cef
+  )
+  find_library(CEF_LIBRARY
+    NAMES cef
+    HINTS ${CEF_ROOT}
+    PATH_SUFFIXES cef
+  )
+  find_library(CEF_DLL_WRAPPER_LIBRARY
+    NAMES cef_dll_wrapper
+    HINTS ${CEF_ROOT}
+    PATH_SUFFIXES cef
+  )
+
+  if (NOT CEF_INCLUDE_DIR OR NOT CEF_LIBRARY OR NOT CEF_DLL_WRAPPER_LIBRARY)
+    message(FATAL_ERROR
+      "BUILD_WEBVIEW_CEF_PLUGIN is ON, but CEF wasn't found:\n"
+      "  headers (include/cef_version.h): ${CEF_INCLUDE_DIR}\n"
+      "  libcef:                          ${CEF_LIBRARY}\n"
+      "  libcef_dll_wrapper:              ${CEF_DLL_WRAPPER_LIBRARY}\n"
+      "Build the `cef` recipe, or point -DCEF_ROOT=<path> at a CEF binary distribution."
+    )
+  endif()
+
+  message(STATUS "CEF .................... ${CEF_LIBRARY}")
+
+  target_sources(flutterpi_module PRIVATE
+    src/plugins/webview_cef/plugin.c
+    src/plugins/webview_cef/cef_bridge.cpp
+  )
+  target_include_directories(flutterpi_module PRIVATE ${CEF_INCLUDE_DIR})
+  target_compile_definitions(flutterpi_module PRIVATE
+    WEBVIEW_CEF_RUNTIME_DIR="${WEBVIEW_CEF_RUNTIME_DIR}"
+    WEBVIEW_CEF_HELPER_PATH="${WEBVIEW_CEF_HELPER_PATH}"
+  )
+  set_target_properties(flutterpi_module PROPERTIES CXX_STANDARD 17 CXX_STANDARD_REQUIRED ON)
+
+  # libcef_dll_wrapper is static and resolves against libcef, so it goes first.
+  target_link_libraries(flutterpi_module PUBLIC ${CEF_DLL_WRAPPER_LIBRARY} ${CEF_LIBRARY})
+  target_link_options(flutterpi_module PUBLIC "-Wl,-rpath,${WEBVIEW_CEF_RUNTIME_DIR}")
+
+  # Chromium's subprocesses (zygote, gpu, renderer) are started by re-executing
+  # a binary. They get their own executable so a renderer never re-enters
+  # flutter-pi's main().
+  add_executable(flutter-pi-cef-helper
+    src/plugins/webview_cef/helper_main.cpp
+    src/plugins/webview_cef/cef_bridge.cpp
+  )
+  target_include_directories(flutter-pi-cef-helper PRIVATE ${CEF_INCLUDE_DIR})
+  target_link_libraries(flutter-pi-cef-helper PRIVATE ${CEF_DLL_WRAPPER_LIBRARY} ${CEF_LIBRARY})
+  target_link_options(flutter-pi-cef-helper PRIVATE "-Wl,-rpath,${WEBVIEW_CEF_RUNTIME_DIR}")
+  set_target_properties(flutter-pi-cef-helper PROPERTIES CXX_STANDARD 17 CXX_STANDARD_REQUIRED ON)
+  install(TARGETS flutter-pi-cef-helper RUNTIME DESTINATION bin)
+endif()
+
 # Needed so dart VM can actually resolve symbols in the same
 # executable. (For dart:ffi DynamicLibrary.executable / DynamicLibrary.process)
 target_link_options(flutterpi_module PUBLIC -rdynamic)
@@ -458,6 +534,14 @@ target_link_libraries(
   flutter-pi PUBLIC
   flutterpi_module
 )
+
+if (BUILD_WEBVIEW_CEF_PLUGIN)
+  # flutterpi_module contains C++ objects (the CEF bridge) now, but flutter-pi's
+  # own source is C, so CMake would pick the C driver to link and leave out the
+  # C++ runtime.
+  set_target_properties(flutter-pi PROPERTIES LINKER_LANGUAGE CXX)
+endif()
+
 install(TARGETS flutter-pi RUNTIME DESTINATION bin)
 
 # Enable lto if supported.

--- a/README.md
+++ b/README.md
@@ -429,6 +429,19 @@ There are several things you need to keep in mind:
         - One of the common reasons is outdated ALSA config in which case you should delete existing config and replace it with up to date one
 - Finally, if you want to verify your audio setup is good, you can use `gst-launch` command to invoke `playbin` on audio file directly.
 
+### webview
+The webview plugin embeds web pages into your app using the [Chromium Embedded Framework](https://bitbucket.org/chromiumembedded/cef). It implements the platform side of the [webview_cef](https://pub.dev/packages/webview_cef) package, so the dart code is the same one you'd write for desktop.
+
+It's off by default, because it needs a CEF binary distribution:
+
+1. Download one for your architecture from [CEF Automated Builds](https://cef-builds.spotifycdn.com) (the "Minimal Distribution" is enough) and unpack it. CEF 126 or newer.
+2. Build `libcef_dll_wrapper` from the sources in that distribution — CEF is meant to be wrapped with your own compiler.
+3. Configure flutter-pi with `-DBUILD_WEBVIEW_CEF_PLUGIN=ON -DCEF_ROOT=<path to the distribution>`.
+
+Pages are rendered off-screen and shown as flutter external textures, since flutter-pi has no platform views. Chromium runs on the headless ozone platform, and gets the GPU through a render node (`/dev/dri/renderD128`), which needs no DRM master and so doesn't collide with flutter-pi holding the card. Page compositing itself is on the CPU — CEF forces that for off-screen rendering — but WebGL and canvas are hardware accelerated. Falls back to software rasterisation if no GL driver is available, which for a WebGL page is the difference between full speed and single-digit fps.
+
+See [src/plugins/webview_cef/README.md](src/plugins/webview_cef/README.md) for the runtime configuration, the implemented channel methods and the known limitations.
+
 ## 📊 Performance
 ### Graphics Performance
 Graphics performance is actually pretty good. With most of the apps inside the `flutter SDK -> examples -> catalog` directory I get smooth 50-60fps on the Pi 4 2GB and Pi 3 A+.
@@ -450,6 +463,7 @@ This is why I created my own (userspace) touchscreen driver, for improved latenc
 | flutterpi_gstreamer_video_player ([package](https://pub.dev/packages/flutterpi_gstreamer_video_player)) ([repo](https://github.com/ardera/flutter_packages/tree/main/packages/flutterpi_gstreamer_video_player)) | ⏯️ multimedia | Hannes Winkler | Official video player implementation for flutter-pi. See [GStreamer video player](#gstreamer-video-player) section above. |
 | charset_converter ([package](https://pub.dev/packages/charset_converter)) ([repo](https://github.com/pr0gramista/charset_converter)) | 🗚 encoding | Bartosz Wiśniewski | Encode and decode charsets using platform built-in converter. |
 | sentry_flutter ([package](https://pub.dev/packages/sentry_flutter)) ([repo](https://github.com/getsentry/sentry-dart))|  📊 Monitoring | sentry.io | See https://github.com/ardera/flutter-pi/wiki/Sentry-Support for instructions. |
+| webview_cef ([package](https://pub.dev/packages/webview_cef)) ([repo](https://github.com/hlwhl/webview_cef)) | 🌐 web | [hlwhl](https://github.com/hlwhl) | Embed web pages using the Chromium Embedded Framework. See [webview](#webview) section above. |
 
 ## 💬 Discord
 There a `#custom-embedders` channel on the [flutter discord](https://github.com/flutter/flutter/wiki/Chat) which you can use if you have any questions regarding flutter-pi or generally, anything related to embedding the engine for which you don't want to open issue about or write an email.

--- a/src/plugins/webview_cef.h
+++ b/src/plugins/webview_cef.h
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: MIT
+/*
+ * CEF powered webview plugin
+ *
+ * Implements the platform side of the `webview_cef` pub package
+ * (https://pub.dev/packages/webview_cef), so flutter apps can embed web pages
+ * on flutter-pi with the same dart code they use on desktop.
+ *
+ * Pages are rendered off-screen by the Chromium Embedded Framework and handed to
+ * flutter as external textures, since flutter-pi has no platform views.
+ *
+ * See src/plugins/webview_cef/README.md.
+ *
+ * Copyright (c) 2026, Bojidar Tonchev <bojidar.tonchev@gmail.com>
+ */
+
+#ifndef _FLUTTERPI_SRC_PLUGINS_WEBVIEW_CEF_H
+#define _FLUTTERPI_SRC_PLUGINS_WEBVIEW_CEF_H
+
+#define WEBVIEW_CEF_CHANNEL "webview_cef"
+
+#endif  // _FLUTTERPI_SRC_PLUGINS_WEBVIEW_CEF_H

--- a/src/plugins/webview_cef/README.md
+++ b/src/plugins/webview_cef/README.md
@@ -1,0 +1,308 @@
+# webview_cef
+
+Platform side of the [`webview_cef`](https://pub.dev/packages/webview_cef) pub
+package, so a flutter app can embed web pages on flutter-pi with the same dart
+code it uses on desktop.
+
+Off by default; enable with `-DBUILD_WEBVIEW_CEF_PLUGIN=ON`.
+
+## How it works
+
+flutter-pi has no platform view support and owns the DRM master, so a browser
+cannot be given a window of its own. Instead:
+
+1. CEF renders the page **off-screen** (`windowless_rendering_enabled`) and hands
+   flutter-pi a BGRA pixel buffer through `CefRenderHandler::OnPaint`.
+2. The plugin uploads that buffer into a GL texture on a context that shares
+   flutter's root context, and publishes it through flutter-pi's texture
+   registry.
+3. The package's dart side shows it with a plain `Texture` widget and forwards
+   pointer input over the platform channel, because an off-screen browser gets no
+   input of its own.
+
+```
+ dart                  flutter-pi (platform thread)          CEF (UI thread)
+ ─────                 ─────────────────────────────         ───────────────
+ Texture(id) ◄─── texture_push_frame ◄── on_paint ◄───────── OnPaint (BGRA)
+ Listener    ───► cursorClickDown ─────► SendMouseClickEvent ────►
+                  webview list, wv->browser ◄── post ◄─────── OnBeforeClose
+```
+
+The frame arrives on CEF's thread and is uploaded there; only the teardown has to
+be handed back, because the webview list belongs to the platform thread.
+
+### Threading
+
+CEF runs the browser process message loop on a thread of its own
+(`multi_threaded_message_loop`), so CEF's *UI thread* is not flutter-pi's platform
+thread. Two threads therefore meet in the plugin:
+
+- platform channel handlers run on the platform thread,
+- every `cef_bridge` callback -- `OnPaint` included -- runs on CEF's UI thread.
+
+Three rules keep that honest. The webview list belongs to the platform thread, so
+`OnBeforeClose` posts its teardown there rather than unlinking anything itself.
+Everything a frame touches on its way to a texture is behind one mutex, because
+the platform thread may be releasing the same webview's textures and the plugin's
+EGL context can only be current on one thread at a time. And sending a platform
+message needs nothing at all: `flutterpi_send_platform_message` posts to the
+platform thread when it isn't already on it.
+
+Only one CEF call has to be marshalled. `CefBrowser` and `CefBrowserHost` are
+documented as callable from any browser process thread, which covers input,
+resize, navigation and close; `CreateBrowserSync` is the exception, so the bridge
+posts it to the UI thread and waits for the browser id the channel reply needs.
+
+The `wvcef_browser` handle is owned by the plugin, not the bridge, and that is
+deliberate. CEF can close a browser on its own -- a renderer crash is the usual
+reason -- and it reports that on its UI thread while the platform thread may be
+part-way through a channel call holding the same handle. A bridge that freed the
+handle from `OnBeforeClose` would pull it out from under that call, so instead the
+handle survives its browser: every call on it becomes a no-op, and the plugin
+releases it with `wvcef_browser_destroy` from the platform thread, where it is the
+only one looking. The webview itself is kept in that case, still showing its last
+frame, because the dart side holds a controller for it and would otherwise get a
+black rectangle with no explanation.
+
+### Why not the external message pump
+
+`external_message_pump` is the other way to do this, and it looks strictly nicer:
+the host drives `CefDoMessageLoopWork()` from its own event loop, the platform
+thread *becomes* CEF's UI thread, and every callback can touch flutter-pi state
+with no locks and no marshalling at all.
+
+It also deadlocks. A Chromium task on the UI thread will sometimes block waiting
+for more UI thread work -- something in the GPU and compositor paths does it
+regularly. A real message loop nests and delivers that work; an external pump
+cannot, because the host is stuck inside its one `CefDoMessageLoopWork()` call
+and has no way to re-enter it. The process then stops for good.
+
+It is worth knowing what that looks like, because none of it points at the pump.
+Everything off the UI thread keeps running -- the network stack, the render
+process -- so the page stays loaded, its JavaScript still runs and its WebSocket
+stays up; it just never paints again. How long it survives depends only on how
+often the blocking path is hit: with software WebGL it lasted about 130 frames,
+with hardware GL about 1600, and with a page that painted but did nothing else it
+looked fine indefinitely. CEF's own documentation recommends against the option.
+
+### Processes
+
+Chromium is multi-process, and on Linux it starts subprocesses by re-executing a
+binary. If that binary were flutter-pi, every renderer would try to boot a
+flutter engine. So the plugin builds a separate `flutter-pi-cef-helper`
+executable and points `CefSettings::browser_subprocess_path` at it.
+
+The sandbox is off (`no_sandbox`), which avoids having to ship the setuid
+`chrome-sandbox` helper.
+
+## Files
+
+| file | what it is |
+| --- | --- |
+| `plugin.c` | the flutter-pi side: platform channel, textures, frame upload |
+| `cef_bridge.h` | plain-C ABI between the two halves |
+| `cef_bridge.cpp` | the CEF side: `CefApp`, `CefClient`, off-screen rendering |
+| `helper_main.cpp` | `main()` of the subprocess helper |
+
+The split exists because flutter-pi's headers cannot be included from C++ --
+`platformchannel.h` and friends use compound literals, which C++ does not have.
+
+## Building
+
+```
+cmake -B build -DBUILD_WEBVIEW_CEF_PLUGIN=ON -DCEF_ROOT=/path/to/cef_binary_..._linux64_minimal
+```
+
+`CEF_ROOT` must contain `include/cef_version.h`, `libcef.so` and
+`libcef_dll_wrapper.a`. Leave it unset to search the (cross) sysroot instead.
+`libcef_dll_wrapper` is the static library that translates CEF's C++ API to its
+stable C ABI; CEF expects you to build it yourself with your own compiler, which
+is why gcc/libstdc++ against a clang/libc++ `libcef.so` is fine.
+
+CEF 126 or newer is required -- that's when `OnBeforePopup` got its `popup_id`
+parameter. There is a `#error` guarding it at the top of `cef_bridge.cpp`.
+Developed against 132.3.2.
+
+Two more cache variables describe the **target** layout:
+
+| variable | default | meaning |
+| --- | --- | --- |
+| `WEBVIEW_CEF_RUNTIME_DIR` | `/usr/lib/cef` | where `libcef.so`, `icudtl.dat`, `*.pak`, `*.bin` and `locales/` live |
+| `WEBVIEW_CEF_HELPER_PATH` | `/usr/bin/flutter-pi-cef-helper` | the subprocess helper |
+
+## Runtime configuration
+
+The `webview_cef` channel only carries a user agent, so everything else is
+configured through the environment. This is also handy while bringing the thing
+up, since none of it needs a recompile.
+
+| environment variable | meaning |
+| --- | --- |
+| `FLUTTERPI_CEF_RUNTIME_DIR` | overrides `WEBVIEW_CEF_RUNTIME_DIR` |
+| `FLUTTERPI_CEF_HELPER` | overrides `WEBVIEW_CEF_HELPER_PATH` |
+| `FLUTTERPI_CEF_CACHE_PATH` | where Chromium may persist its cache. Unset = in-memory profile |
+| `FLUTTERPI_CEF_SWITCHES` | extra Chromium switches, comma separated, without `--` |
+| `FLUTTERPI_CEF_NO_DEFAULT_SWITCHES` | if set, don't pass the default switches below |
+| `FLUTTERPI_CEF_LOG_FILE` | Chromium's log file (default: stderr) |
+| `FLUTTERPI_CEF_LOG_SEVERITY` | 1 verbose, 2 info, 3 warning, 4 error, 5 fatal, 99 off |
+| `FLUTTERPI_CEF_FRAME_RATE` | `windowless_frame_rate`, 1..60 (default 30) |
+| `FLUTTERPI_CEF_EAGER_INIT` | if set, start CEF during plugin init instead of on the first `init`/`create` |
+| `FLUTTERPI_CEF_TRACE` | `1` logs browser creation, `setSize` and the frames arriving from CEF; `2` adds every frame step by step |
+| `FLUTTERPI_CEF_FORCE_RGBA` | if set, convert frames to RGBA on the CPU instead of uploading BGRA directly |
+
+`FLUTTERPI_CEF_TRACE=1` answers the first question a blank webview raises: is CEF
+painting at all, and at what size? It prints the first three frames per browser
+and then every hundredth, so it is usable on a running release build -- unlike
+`LOG_DEBUG`, which is compiled out of exactly the builds that need explaining.
+
+Level `2` prints each frame's steps, flushed as it goes, for the case where a
+frame stops halfway: taking the texture mutex, making the EGL context current and
+`glFinish` can all block, and the last line printed says which call didn't return.
+Useful on a target with no debugger on it.
+
+`FLUTTERPI_CEF_EAGER_INIT` exists because plugins are initialized *before* the
+flutter engine is created. Starting CEF there means Chromium forks its helper
+processes out of a process that is not heavily threaded yet, and installs its
+signal handlers first. It is the safer ordering, and it moves `CefInitialize`'s
+half second off the first `init` call -- at the cost of paying Chromium's memory
+even if no webview is ever opened.
+
+The switches passed by default:
+
+```
+--ozone-platform=headless           there is no X server and no compositor
+--use-gl=angle                      ANGLE on native EGL/GLES, i.e. Mesa on a
+--use-angle=gl-egl                    render node -- see "GPU" below
+--ignore-gpu-blocklist              an embedded GPU won't be on the known-good list
+--enable-unsafe-swiftshader         software WebGL, only if the above fails
+--disable-dev-shm-usage
+--autoplay-policy=no-user-gesture-required
+```
+
+The plugin also sets `EGL_PLATFORM=surfaceless` (without overwriting an existing
+value) before `CefInitialize`, because the GL switches above do nothing without
+it -- see "GPU". If the page stays blank, or Chromium dies during startup, this is
+the list to experiment with:
+
+```bash
+FLUTTERPI_CEF_TRACE=1 FLUTTERPI_CEF_LOG_SEVERITY=1 FLUTTERPI_CEF_SWITCHES=enable-logging=stderr,v=1 flutter-pi --release /path/to/bundle
+```
+
+### GPU
+
+Chromium and flutter-pi can share the GPU, and it is worth making sure they do.
+flutter-pi holds DRM master on the card node, but Chromium doesn't need master --
+it only needs a *render* node, `/dev/dri/renderD128`, which is exactly what render
+nodes are for. So the two coexist, and WebGL and canvas run on the real GPU.
+
+Getting there needs two things that are easy to miss, because missing them costs
+performance rather than correctness:
+
+1. `--use-gl=angle --use-angle=gl-egl`, so Chromium uses ANGLE over native
+   EGL/GLES instead of its bundled SwiftShader.
+2. `EGL_PLATFORM=surfaceless`, because Mesa's EGL otherwise defaults to the X11
+   platform. There is no X server, `eglInitialize` fails with *"Could not open the
+   default X display"*, and Chromium falls back to SwiftShader.
+
+That fallback is the thing to watch for. It is silent: the page loads, WebGL
+reports a working context, everything renders correctly -- just slowly, with the
+CPU doing the rasterisation. On a Celeron J6412 a WebGL slot game ran at about
+**3fps**, with SwiftShader's four worker threads saturating all four cores, and at
+full speed with **~3%** CPU in the GPU process once Mesa was actually in use.
+
+To check which one you got, on the target:
+
+```bash
+# find the GPU process, then look at what it loaded
+for p in $(pidof flutter-pi-cef-helper); do grep -aq type=gpu-process /proc/$p/cmdline && echo $p; done
+```
+
+With hardware GL that process has `/dev/dri/renderD128` among its open `fd`s and
+the Mesa driver (`iris_dri.so`, `v3d_dri.so`, ...) in its `maps`. On SwiftShader it
+has neither, its command line says `--use-angle=swiftshader-webgl`, and its hottest
+threads are named `Thread<00>`, `Thread<01>`, ... -- SwiftShader's worker pool, and
+an unmistakable signature once you have seen it.
+
+## Implemented channel methods
+
+Channel `webview_cef`, standard method codec. Arguments are positional lists, or
+a bare value for the single-argument methods -- that is what the package's dart
+side sends.
+
+| method | arguments | returns |
+| --- | --- | --- |
+| `init` | userAgent (String), or nothing | null |
+| `create` | url (String) | `[browserId, textureId]` |
+| `close` | browserId | null |
+| `loadUrl` | `[browserId, url]` | null |
+| `reload` / `goBack` / `goForward` | browserId | null |
+| `setSize` | `[browserId, dpi, width, height]` | null |
+| `cursorMove` / `cursorDragging` | `[browserId, x, y]` | null |
+| `cursorClickDown` / `cursorClickUp` | `[browserId, x, y]` | null |
+| `setScrollDelta` | `[browserId, x, y, deltaX, deltaY]` | null |
+| `setClientFocus` | `[browserId, focus]` | null |
+| `executeJavaScript` | `[browserId, code]` | null |
+| `imeCommitText` / `imeSetComposition` | `[browserId, text]` | null |
+| `quit` | none | null |
+
+Sizes and coordinates are logical pixels; `dpi` is the device pixel ratio.
+
+Events back to dart, as method calls on the same channel, all carrying
+`browserId` in a map: `urlChanged`, `titleChanged`, `onLoadStart`, `onLoadEnd`,
+`onTooltip`, `onCursorChanged`, `onConsoleMessage`.
+
+`quit` only closes the browsers, it does not call `CefShutdown` -- CEF cannot be
+initialized twice in one process, so shutting down on `quit` would break every
+later webview. CEF is torn down in the plugin's deinit instead.
+
+## Not implemented
+
+These respond with "not implemented", so the dart side gets a clear
+`MissingPluginException` rather than silence:
+
+- `evaluateJavascript`, `setJavaScriptChannels`, `sendJavaScriptChannelCallBack`
+  -- need a `CefRenderProcessHandler` in the helper plus IPC to get values back
+  out of V8. `executeJavaScript` (fire and forget) does work.
+- `openDevTools` -- needs a real window to put the inspector in.
+- `setCookie`, `deleteCookie`, `visitAllCookies`, `visitUrlCookies` --
+  straightforward on top of `CefCookieManager`, just not done yet.
+- The `onFocusedNodeChangeMessage` and `onImeCompositionRangeChangedMessage`
+  events -- `CefRenderProcessHandler::OnFocusedNodeChanged` fires in the render
+  process, so reporting it needs process messages between the helper and here.
+
+### Typing into a page
+
+`imeCommitText` and `imeSetComposition` are implemented, so text input works --
+but the package's dart side only attaches flutter's text input client after it
+receives `onFocusedNodeChangeMessage`, which is in the list above. So a page that
+focuses an `<input>` on its own does **not** get a keyboard yet.
+
+An app with its own on-screen keyboard can drive it directly in the meantime:
+
+```dart
+controller.imeCommitText('5');
+```
+
+Wiring up the focus notification is the missing piece for automatic keyboard
+handling, and it's the main thing left to do here.
+
+## Other limitations
+
+- **One GL texture per webview, reused every frame.** If flutter's rasterizer is
+  sampling frame N while frame N+1 is uploaded, that frame can tear. Double
+  buffering would fix it at the cost of memory.
+- **Dirty rects are ignored**; every paint uploads the whole surface. GLES2 has
+  no `GL_UNPACK_ROW_LENGTH`, so partial uploads would need a per-row loop.
+- **Page compositing happens on the CPU**, whatever the GPU does. CEF forces
+  `--disable-gpu-compositing` for windowless rendering unless shared textures are
+  enabled, and it does so on its own -- it shows up in the renderer command lines
+  without being passed. WebGL and canvas still get the GPU (see below); it is the
+  final compositing step that is software, plus a `ReadPixels` per frame to get
+  the result into the buffer `OnPaint` wants.
+- **Popups** (`<select>` dropdowns) are composited into the view buffer while
+  they are open, which costs one extra full-frame copy per paint. Nothing is
+  copied when no popup is open.
+- **`target=_blank` and `window.open()`** load into the same view instead of
+  opening a second window.
+- **Touch input arrives as mouse input**, because that is what the package's dart
+  side sends. Multi-touch gestures inside the page are not available.

--- a/src/plugins/webview_cef/cef_bridge.cpp
+++ b/src/plugins/webview_cef/cef_bridge.cpp
@@ -1,0 +1,982 @@
+// SPDX-License-Identifier: MIT
+/*
+ * CEF bridge
+ *
+ * Implements the plain-C API declared in cef_bridge.h on top of CEF's C++ API.
+ *
+ * This file must not include any flutter-pi header -- see cef_bridge.h for why.
+ *
+ * Copyright (c) 2026, Bojidar Tonchev <bojidar.tonchev@gmail.com>
+ */
+
+#include "cef_bridge.h"
+
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <vector>
+
+#include "include/cef_app.h"
+#include "include/cef_browser.h"
+#include "include/cef_client.h"
+#include "include/cef_task.h"
+#include "include/cef_version.h"
+
+// Written against CEF 132. CEF 126 added the popup_id parameter to OnBeforePopup,
+// which would otherwise surface as a confusing "marked override but does not
+// override" error, so fail loudly instead.
+#if CEF_VERSION_MAJOR < 126
+    #error "The webview_cef plugin requires CEF 126 or newer."
+#endif
+
+#define LOG_CEF(...) fprintf(stderr, "[webview_cef] " __VA_ARGS__)
+
+namespace {
+
+/// Runs a closure on a CEF thread. Written against CefTask directly rather than
+/// base::BindOnce so it depends only on cef_task.h.
+class FnTask : public CefTask {
+public:
+    explicit FnTask(std::function<void()> fn)
+            : fn_(std::move(fn)) {
+    }
+
+    FnTask(const FnTask &) = delete;
+    FnTask &operator=(const FnTask &) = delete;
+
+    void Execute() override {
+        fn_();
+    }
+
+private:
+    std::function<void()> fn_;
+
+    IMPLEMENT_REFCOUNTING(FnTask);
+};
+
+void post_to_ui(std::function<void()> fn) {
+    CefPostTask(TID_UI, CefRefPtr<CefTask>(new FnTask(std::move(fn))));
+}
+
+// ---------------------------------------------------------------------------
+// CefApp -- one per process.
+// ---------------------------------------------------------------------------
+
+class WebviewApp : public CefApp, public CefBrowserProcessHandler {
+public:
+    explicit WebviewApp(std::vector<std::string> switches)
+            : switches_(std::move(switches)) {
+    }
+
+    WebviewApp(const WebviewApp &) = delete;
+    WebviewApp &operator=(const WebviewApp &) = delete;
+
+    CefRefPtr<CefBrowserProcessHandler> GetBrowserProcessHandler() override {
+        return this;
+    }
+
+    void OnBeforeCommandLineProcessing(const CefString &process_type, CefRefPtr<CefCommandLine> command_line) override {
+        // An empty process type means the browser process. Switches appended
+        // here are inherited by the subprocesses, so only do it once.
+        if (!process_type.empty()) {
+            return;
+        }
+
+        for (const std::string &sw : switches_) {
+            const size_t eq = sw.find('=');
+            if (eq == std::string::npos) {
+                command_line->AppendSwitch(sw);
+            } else {
+                command_line->AppendSwitchWithValue(sw.substr(0, eq), sw.substr(eq + 1));
+            }
+        }
+    }
+
+private:
+    std::vector<std::string> switches_;
+
+    IMPLEMENT_REFCOUNTING(WebviewApp);
+};
+
+// ---------------------------------------------------------------------------
+// CefClient -- one per webview.
+// ---------------------------------------------------------------------------
+
+typedef void (*gone_cb_t)(void *userdata);
+
+class WebviewClient : public CefClient,
+                      public CefLifeSpanHandler,
+                      public CefRenderHandler,
+                      public CefLoadHandler,
+                      public CefDisplayHandler {
+public:
+    WebviewClient(int logical_width, int logical_height, double scale, const struct wvcef_host_callbacks *callbacks, void *userdata)
+            : logical_width_(logical_width)
+            , logical_height_(logical_height)
+            , scale_(scale)
+            , callbacks_(*callbacks)
+            , userdata_(userdata) {
+    }
+
+    WebviewClient(const WebviewClient &) = delete;
+    WebviewClient &operator=(const WebviewClient &) = delete;
+
+    // -- CefClient ----------------------------------------------------------
+    CefRefPtr<CefLifeSpanHandler> GetLifeSpanHandler() override {
+        return this;
+    }
+    CefRefPtr<CefRenderHandler> GetRenderHandler() override {
+        return this;
+    }
+    CefRefPtr<CefLoadHandler> GetLoadHandler() override {
+        return this;
+    }
+    CefRefPtr<CefDisplayHandler> GetDisplayHandler() override {
+        return this;
+    }
+
+    // -- CefLifeSpanHandler -------------------------------------------------
+    void OnAfterCreated(CefRefPtr<CefBrowser> browser) override {
+        std::lock_guard<std::mutex> lock(state_mutex_);
+        browser_ = browser;
+    }
+
+    bool DoClose(CefRefPtr<CefBrowser> browser) override {
+        (void) browser;
+        // Let the close proceed; OnBeforeClose follows.
+        return false;
+    }
+
+    void OnBeforeClose(CefRefPtr<CefBrowser> browser) override {
+        (void) browser;
+
+        // Kept alive until `dying` goes out of scope at the end of this function,
+        // so the last reference isn't dropped with the lock held.
+        CefRefPtr<CefBrowser> dying;
+        {
+            std::lock_guard<std::mutex> lock(state_mutex_);
+            dying = browser_;
+            browser_ = nullptr;
+        }
+
+        // This is the last callback for this browser, and the host frees the
+        // object `userdata_` points at while handling it. Drop both before
+        // calling out, so a stray later callback can't use a dangling pointer.
+        const struct wvcef_host_callbacks callbacks = callbacks_;
+        void *const userdata = userdata_;
+
+        memset(&callbacks_, 0, sizeof callbacks_);
+        userdata_ = nullptr;
+
+        if (callbacks.on_closed != nullptr) {
+            callbacks.on_closed(userdata);
+        }
+
+        // Hand the C handle to the bridge for disposal. It only queues it --
+        // releasing the last reference to this client from inside one of its own
+        // methods would destroy `this` while we're still running.
+        if (on_gone_ != nullptr) {
+            gone_cb_t cb = on_gone_;
+            void *ud = on_gone_userdata_;
+            on_gone_ = nullptr;
+            cb(ud);
+        }
+    }
+
+    /// Parameters we don't use are left unnamed -- this signature is long enough
+    /// as it is.
+    bool
+    OnBeforePopup(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame>, int /* popup_id */, const CefString &target_url, const CefString &, CefLifeSpanHandler::WindowOpenDisposition, bool, const CefPopupFeatures &, CefWindowInfo &, CefRefPtr<CefClient> &, CefBrowserSettings &, CefRefPtr<CefDictionaryValue> &, bool *)
+        override {
+        return redirect_popup(browser, target_url);
+    }
+
+    // -- CefRenderHandler ---------------------------------------------------
+    void GetViewRect(CefRefPtr<CefBrowser> browser, CefRect &rect) override {
+        (void) browser;
+
+        std::lock_guard<std::mutex> lock(state_mutex_);
+        rect.x = 0;
+        rect.y = 0;
+        rect.width = logical_width_ > 0 ? logical_width_ : 1;
+        rect.height = logical_height_ > 0 ? logical_height_ : 1;
+    }
+
+    bool GetScreenInfo(CefRefPtr<CefBrowser> browser, CefScreenInfo &screen_info) override {
+        (void) browser;
+
+        std::lock_guard<std::mutex> lock(state_mutex_);
+
+        screen_info.device_scale_factor = static_cast<float>(scale_);
+        screen_info.depth = 32;
+        screen_info.depth_per_component = 8;
+        screen_info.is_monochrome = 0;
+        screen_info.rect = CefRect(0, 0, logical_width_ > 0 ? logical_width_ : 1, logical_height_ > 0 ? logical_height_ : 1);
+        screen_info.available_rect = screen_info.rect;
+        return true;
+    }
+
+    bool GetScreenPoint(CefRefPtr<CefBrowser> browser, int view_x, int view_y, int &screen_x, int &screen_y) override {
+        (void) browser;
+        screen_x = view_x;
+        screen_y = view_y;
+        return true;
+    }
+
+    void OnPopupShow(CefRefPtr<CefBrowser> browser, bool show) override {
+        popup_visible_ = show;
+
+        if (!show) {
+            popup_rect_ = CefRect();
+            popup_buffer_.clear();
+            view_buffer_.clear();
+        }
+
+        // Repaint so the popup appears / disappears right away. This also gives
+        // us the full view frame we need to composite the popup onto.
+        if (browser != nullptr) {
+            browser->GetHost()->Invalidate(PET_VIEW);
+        }
+    }
+
+    void OnPopupSize(CefRefPtr<CefBrowser> browser, const CefRect &rect) override {
+        (void) browser;
+        popup_rect_ = rect;
+    }
+
+    void
+    OnPaint(CefRefPtr<CefBrowser> browser, PaintElementType type, const RectList &dirty_rects, const void *buffer, int width, int height)
+        override {
+        (void) browser;
+        // Dirty rects are ignored: GLES2 has no GL_UNPACK_ROW_LENGTH, so a
+        // partial upload would need a per-row loop that costs more than it saves.
+        (void) dirty_rects;
+
+        if (callbacks_.on_paint == nullptr || buffer == nullptr || width <= 0 || height <= 0) {
+            return;
+        }
+
+        const uint8_t *bytes = static_cast<const uint8_t *>(buffer);
+        const size_t n_bytes = static_cast<size_t>(width) * static_cast<size_t>(height) * 4;
+
+        if (type == PET_POPUP) {
+            popup_width_ = width;
+            popup_height_ = height;
+            popup_buffer_.assign(bytes, bytes + n_bytes);
+
+            if (!view_buffer_.empty()) {
+                composite_and_emit();
+            }
+            return;
+        }
+
+        if (!popup_visible_) {
+            // Fast path: hand CEF's buffer straight to the host, no copy.
+            callbacks_.on_paint(userdata_, buffer, width, height);
+            return;
+        }
+
+        view_width_ = width;
+        view_height_ = height;
+        view_buffer_.assign(bytes, bytes + n_bytes);
+        composite_and_emit();
+    }
+
+    bool
+    OnCursorChange(CefRefPtr<CefBrowser> browser, CefCursorHandle cursor, cef_cursor_type_t type, const CefCursorInfo &custom_cursor_info)
+        override {
+        (void) browser;
+        (void) cursor;
+        (void) custom_cursor_info;
+
+        if (callbacks_.on_cursor_changed != nullptr) {
+            callbacks_.on_cursor_changed(userdata_, static_cast<int>(type));
+        }
+
+        // Return true to say we handled it -- there is no window system for CEF
+        // to set a cursor on.
+        return true;
+    }
+
+    // -- CefLoadHandler -----------------------------------------------------
+    void OnLoadStart(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame, TransitionType transition_type) override {
+        (void) browser;
+        (void) transition_type;
+
+        if (frame == nullptr || !frame->IsMain() || callbacks_.on_load_start == nullptr) {
+            return;
+        }
+
+        const std::string url = frame->GetURL().ToString();
+        callbacks_.on_load_start(userdata_, url.c_str());
+    }
+
+    void OnLoadEnd(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame, int http_status_code) override {
+        (void) browser;
+
+        if (frame == nullptr || !frame->IsMain() || callbacks_.on_load_end == nullptr) {
+            return;
+        }
+
+        const std::string url = frame->GetURL().ToString();
+        callbacks_.on_load_end(userdata_, url.c_str(), http_status_code);
+    }
+
+    void OnLoadError(
+        CefRefPtr<CefBrowser> browser,
+        CefRefPtr<CefFrame> frame,
+        ErrorCode error_code,
+        const CefString &error_text,
+        const CefString &failed_url
+    ) override {
+        (void) browser;
+
+        // Sub-frame errors are noise for the app; only report the main frame.
+        if (frame != nullptr && !frame->IsMain()) {
+            return;
+        }
+
+        if (callbacks_.on_load_error != nullptr) {
+            const std::string text = error_text.ToString();
+            const std::string url = failed_url.ToString();
+            callbacks_.on_load_error(userdata_, static_cast<int>(error_code), text.c_str(), url.c_str());
+        }
+    }
+
+    // -- CefDisplayHandler --------------------------------------------------
+    void OnAddressChange(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame, const CefString &url) override {
+        (void) browser;
+
+        if (frame != nullptr && !frame->IsMain()) {
+            return;
+        }
+
+        if (callbacks_.on_url_changed != nullptr) {
+            const std::string str = url.ToString();
+            callbacks_.on_url_changed(userdata_, str.c_str());
+        }
+    }
+
+    void OnTitleChange(CefRefPtr<CefBrowser> browser, const CefString &title) override {
+        (void) browser;
+        if (callbacks_.on_title_changed != nullptr) {
+            const std::string str = title.ToString();
+            callbacks_.on_title_changed(userdata_, str.c_str());
+        }
+    }
+
+    bool OnTooltip(CefRefPtr<CefBrowser> browser, CefString &text) override {
+        (void) browser;
+
+        if (callbacks_.on_tooltip != nullptr) {
+            const std::string str = text.ToString();
+            callbacks_.on_tooltip(userdata_, str.c_str());
+        }
+
+        // The dart side draws the tooltip.
+        return true;
+    }
+
+    bool
+    OnConsoleMessage(CefRefPtr<CefBrowser> browser, cef_log_severity_t level, const CefString &message, const CefString &source, int line)
+        override {
+        (void) browser;
+
+        if (callbacks_.on_console_message != nullptr) {
+            const std::string message_str = message.ToString();
+            const std::string source_str = source.ToString();
+            callbacks_.on_console_message(userdata_, static_cast<int>(level), message_str.c_str(), source_str.c_str(), line);
+        }
+
+        // Let CEF log it as well.
+        return false;
+    }
+
+    // -- Used by the C API --------------------------------------------------
+
+    /// A strong reference, so the caller can keep using the browser even if CEF
+    /// closes it in the meantime. Null once it's gone.
+    CefRefPtr<CefBrowser> browser() const {
+        std::lock_guard<std::mutex> lock(state_mutex_);
+        return browser_;
+    }
+
+    /// Only called while the browser is being set up or torn down, never
+    /// concurrently with OnBeforeClose, so it needs no lock.
+    void set_on_gone(gone_cb_t cb, void *userdata) {
+        on_gone_ = cb;
+        on_gone_userdata_ = userdata;
+    }
+
+    void set_size(int logical_width, int logical_height, double scale) {
+        std::lock_guard<std::mutex> lock(state_mutex_);
+        logical_width_ = logical_width;
+        logical_height_ = logical_height;
+        scale_ = scale;
+    }
+
+private:
+    /// There is nowhere to put a second window, so target=_blank and
+    /// window.open() load into this view instead of spawning a popup browser
+    /// that nothing would ever render.
+    bool redirect_popup(CefRefPtr<CefBrowser> browser, const CefString &target_url) {
+        if (browser != nullptr && !target_url.empty()) {
+            browser->GetMainFrame()->LoadURL(target_url);
+        }
+
+        // Cancel the popup.
+        return true;
+    }
+
+    /// Draws popup_buffer_ over a copy of view_buffer_ and emits the result.
+    void composite_and_emit() {
+        if (view_buffer_.empty() || view_width_ <= 0 || view_height_ <= 0) {
+            return;
+        }
+
+        composite_buffer_ = view_buffer_;
+
+        if (!popup_buffer_.empty() && popup_width_ > 0 && popup_height_ > 0) {
+            // Read once, and not while the host callback below is running -- the
+            // host takes locks of its own in on_paint.
+            double scale;
+            {
+                std::lock_guard<std::mutex> lock(state_mutex_);
+                scale = scale_;
+            }
+
+            // popup_rect_ is logical, the buffers are physical pixels.
+            const int off_x = static_cast<int>(popup_rect_.x * scale);
+            const int off_y = static_cast<int>(popup_rect_.y * scale);
+
+            for (int row = 0; row < popup_height_; row++) {
+                const int dst_y = off_y + row;
+                if (dst_y < 0 || dst_y >= view_height_) {
+                    continue;
+                }
+
+                int dst_x = off_x;
+                int src_x = 0;
+                int n_px = popup_width_;
+
+                if (dst_x < 0) {
+                    src_x = -dst_x;
+                    n_px -= src_x;
+                    dst_x = 0;
+                }
+                if (dst_x + n_px > view_width_) {
+                    n_px = view_width_ - dst_x;
+                }
+                if (n_px <= 0) {
+                    continue;
+                }
+
+                memcpy(
+                    composite_buffer_.data() + (static_cast<size_t>(dst_y) * view_width_ + dst_x) * 4,
+                    popup_buffer_.data() + (static_cast<size_t>(row) * popup_width_ + src_x) * 4,
+                    static_cast<size_t>(n_px) * 4
+                );
+            }
+        }
+
+        callbacks_.on_paint(userdata_, composite_buffer_.data(), view_width_, view_height_);
+    }
+
+    /// Guards `browser_` and the geometry below -- the only members touched from
+    /// more than one thread. CEF sets and clears browser_ on its UI thread and
+    /// reads the geometry there (GetViewRect, GetScreenInfo), while the host reads
+    /// browser_ and writes the geometry (set_size) from its own thread.
+    ///
+    /// Never held while calling a host callback: those take locks of their own.
+    mutable std::mutex state_mutex_;
+
+    CefRefPtr<CefBrowser> browser_;
+
+    int logical_width_;
+    int logical_height_;
+    double scale_;
+
+    struct wvcef_host_callbacks callbacks_;
+    void *userdata_;
+
+    gone_cb_t on_gone_ = nullptr;
+    void *on_gone_userdata_ = nullptr;
+
+    bool popup_visible_ = false;
+    CefRect popup_rect_;
+    std::vector<uint8_t> popup_buffer_;
+    int popup_width_ = 0;
+    int popup_height_ = 0;
+
+    std::vector<uint8_t> view_buffer_;
+    std::vector<uint8_t> composite_buffer_;
+    int view_width_ = 0;
+    int view_height_ = 0;
+
+    IMPLEMENT_REFCOUNTING(WebviewClient);
+};
+
+bool g_initialized = false;
+
+/// Incremented on whichever thread creates a browser, decremented on CEF's UI
+/// thread when one closes, read from both.
+std::atomic<int> g_n_live_browsers{ 0 };
+
+CefRefPtr<WebviewApp> g_app;
+
+cef_log_severity_t to_log_severity(int severity) {
+    switch (severity) {
+        case 1: return LOGSEVERITY_VERBOSE;
+        case 2: return LOGSEVERITY_INFO;
+        case 3: return LOGSEVERITY_WARNING;
+        case 4: return LOGSEVERITY_ERROR;
+        case 5: return LOGSEVERITY_FATAL;
+        case 99: return LOGSEVERITY_DISABLE;
+        default: return LOGSEVERITY_DEFAULT;
+    }
+}
+
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// C API
+// ---------------------------------------------------------------------------
+
+/// Handle handed out to the C side. Owned by the *caller*, which releases it with
+/// wvcef_browser_destroy() once on_closed has told it the browser is gone.
+///
+/// Not thread safe in itself -- the owner serialises its own calls, which plugin.c
+/// does by only ever touching a handle from flutter-pi's platform thread. What it
+/// does survive is CEF closing the browser underneath it on another thread: the
+/// client outlives that, its browser() goes null, and every call below turns into a
+/// no-op until the owner gets around to destroying the handle.
+struct wvcef_browser {
+    CefRefPtr<WebviewClient> client;
+    bool close_requested;
+};
+
+namespace {
+
+/// Called on CEF's UI thread, from inside the client's own OnBeforeClose.
+///
+/// Deliberately does *not* free the handle. The owner is still holding that
+/// pointer on another thread and has no way to know it just became invalid;
+/// freeing it here is a use-after-free waiting for the next event the browser
+/// happens to get. It goes away in wvcef_browser_destroy() instead.
+void on_client_gone(void *userdata) {
+    (void) userdata;
+
+    // Only ever decremented here, and OnBeforeClose is always on the UI thread,
+    // so the read and the decrement can't interleave with another decrement.
+    if (g_n_live_browsers.load() > 0) {
+        g_n_live_browsers--;
+    }
+}
+
+CefRefPtr<CefBrowser> browser_of(struct wvcef_browser *browser) {
+    if (browser == nullptr || browser->client == nullptr) {
+        return nullptr;
+    }
+    return browser->client->browser();
+}
+
+}  // namespace
+
+int wvcef_execute_subprocess(int argc, char **argv) {
+    CefMainArgs main_args(argc, argv);
+    return CefExecuteProcess(main_args, nullptr, nullptr);
+}
+
+int wvcef_initialize(const struct wvcef_init_options *options) {
+    if (options == nullptr) {
+        return 22 /* EINVAL */;
+    }
+
+    if (g_initialized) {
+        return 0;
+    }
+
+    if (options->subprocess_path == nullptr || options->resources_dir == nullptr || options->locales_dir == nullptr) {
+        LOG_CEF("wvcef_initialize: subprocess_path, resources_dir and locales_dir are required.\n");
+        return 22 /* EINVAL */;
+    }
+
+    std::vector<std::string> switches;
+    for (size_t i = 0; i < options->n_switches; i++) {
+        if (options->switches[i] != nullptr && options->switches[i][0] != '\0') {
+            switches.emplace_back(options->switches[i]);
+        }
+    }
+
+    g_app = new WebviewApp(std::move(switches));
+
+    // Don't hand flutter-pi's own argv to Chromium -- it would try to interpret
+    // "--release" and the asset bundle path as Chromium switches. Everything we
+    // want on the command line is appended in OnBeforeCommandLineProcessing.
+    char argv0[] = "flutter-pi";
+    char *fake_argv[] = { argv0, nullptr };
+    CefMainArgs main_args(1, fake_argv);
+
+    CefSettings settings;
+    settings.no_sandbox = 1;
+    settings.windowless_rendering_enabled = 1;
+
+    // CEF gets its own thread for the browser process message loop.
+    //
+    // The alternative, external_message_pump, lets the host drive the loop from
+    // its own event loop and makes the host thread CEF's UI thread -- which is
+    // tempting, because then every callback can touch host state with no locks.
+    // But a Chromium task on the UI thread will sometimes block waiting for more
+    // UI thread work, and only a real message loop can nest and deliver it; an
+    // external pump is stuck inside its one CefDoMessageLoopWork() call. When that
+    // happens the process stops for good with the page still looking alive. It is
+    // not a corner case -- a WebGL page reached it within seconds -- and CEF's own
+    // documentation recommends against the option for exactly this sort of reason.
+    settings.external_message_pump = 0;
+    settings.multi_threaded_message_loop = 1;
+
+    settings.command_line_args_disabled = 0;
+    settings.log_severity = to_log_severity(options->log_severity);
+
+    CefString(&settings.browser_subprocess_path).FromString(options->subprocess_path);
+    CefString(&settings.resources_dir_path).FromString(options->resources_dir);
+    CefString(&settings.locales_dir_path).FromString(options->locales_dir);
+
+    if (options->cache_path != nullptr && options->cache_path[0] != '\0') {
+        CefString(&settings.cache_path).FromString(options->cache_path);
+        // CEF >= 120 wants root_cache_path set, with cache_path equal to it or
+        // below it.
+        CefString(&settings.root_cache_path).FromString(options->cache_path);
+    }
+    if (options->user_agent != nullptr && options->user_agent[0] != '\0') {
+        CefString(&settings.user_agent).FromString(options->user_agent);
+    }
+    if (options->log_file != nullptr && options->log_file[0] != '\0') {
+        CefString(&settings.log_file).FromString(options->log_file);
+    }
+
+    if (!CefInitialize(main_args, settings, g_app, nullptr)) {
+        LOG_CEF("CefInitialize failed.\n");
+        g_app = nullptr;
+        return 5 /* EIO */;
+    }
+
+    g_initialized = true;
+    // CEF_VERSION is the only version macro that's spelled the same across
+    // releases; it reads like "132.3.2+g4997b2f+chromium-132.0.6834.161".
+    LOG_CEF("CEF %s initialized.\n", CEF_VERSION);
+    return 0;
+}
+
+bool wvcef_is_initialized(void) {
+    return g_initialized;
+}
+
+int wvcef_n_live_browsers(void) {
+    return g_n_live_browsers.load();
+}
+
+void wvcef_shutdown(void) {
+    if (!g_initialized) {
+        return;
+    }
+
+    g_initialized = false;
+
+    // Stops CEF's message loop thread and joins it, so any handle-freeing task
+    // still queued on the UI thread has run by the time this returns.
+    CefShutdown();
+    g_app = nullptr;
+}
+
+struct wvcef_browser *wvcef_browser_create(
+    const char *url,
+    int width,
+    int height,
+    double device_pixel_ratio,
+    int frame_rate,
+    const struct wvcef_host_callbacks *callbacks,
+    void *userdata
+) {
+    if (!g_initialized || callbacks == nullptr) {
+        return nullptr;
+    }
+
+    if (width <= 0) {
+        width = 1;
+    }
+    if (height <= 0) {
+        height = 1;
+    }
+    if (device_pixel_ratio <= 0.0) {
+        device_pixel_ratio = 1.0;
+    }
+    if (frame_rate < 1) {
+        frame_rate = 30;
+    } else if (frame_rate > 60) {
+        frame_rate = 60;
+    }
+
+    struct wvcef_browser *handle = new struct wvcef_browser();
+    handle->close_requested = false;
+    handle->client = new WebviewClient(width, height, device_pixel_ratio, callbacks, userdata);
+    handle->client->set_on_gone(on_client_gone, handle);
+
+    const std::string target = (url != nullptr && url[0] != '\0') ? url : "about:blank";
+
+    // CreateBrowserSync is the one CEF call in this file that insists on the UI
+    // thread -- everything else is documented as callable from any browser process
+    // thread -- so it is posted there and this thread waits for the answer. The
+    // caller needs the browser id to answer the channel call that asked for a
+    // webview, and there is no id until the browser exists.
+    //
+    // Shared state on the heap, not captured by reference: on the timeout path
+    // this function returns while the task may still be queued, and a task writing
+    // into a stack frame that has gone away is a far worse problem than the one
+    // the timeout is protecting against.
+    struct create_state {
+        std::mutex lock;
+        std::condition_variable cv;
+        bool done = false;
+        bool created = false;
+    };
+    auto state = std::make_shared<create_state>();
+
+    // Counted before the browser exists, not after: OnBeforeClose decrements, and
+    // a browser that closes the instant it opens would otherwise decrement a zero
+    // that this thread then raises to one -- leaving a phantom browser that
+    // wvcef_shutdown() waits for forever.
+    g_n_live_browsers++;
+
+    post_to_ui([state, handle, target, frame_rate]() {
+        CefWindowInfo window_info;
+        window_info.SetAsWindowless(0);
+
+        CefBrowserSettings browser_settings;
+        browser_settings.windowless_frame_rate = frame_rate;
+        browser_settings.background_color = CefColorSetARGB(255, 255, 255, 255);
+
+        const bool ok =
+            CefBrowserHost::CreateBrowserSync(window_info, handle->client, CefString(target), browser_settings, nullptr, nullptr) !=
+            nullptr;
+
+        std::lock_guard<std::mutex> guard(state->lock);
+        state->created = ok;
+        state->done = true;
+        state->cv.notify_one();
+    });
+
+    {
+        std::unique_lock<std::mutex> guard(state->lock);
+        if (!state->cv.wait_for(guard, std::chrono::seconds(15), [&state]() { return state->done; })) {
+            LOG_CEF("Timed out waiting for CEF's UI thread to create a browser.\n");
+            // The task may still run and use `handle`, so it can't be freed here.
+            // One leaked handle is the lesser evil. The live count stays raised for
+            // the same reason -- the browser may yet appear -- which costs shutdown
+            // the couple of seconds it is prepared to wait.
+            return nullptr;
+        }
+
+        if (!state->created) {
+            LOG_CEF("CefBrowserHost::CreateBrowserSync failed.\n");
+            // The task has run and no browser came of it, so OnBeforeClose will
+            // never fire for this one: undo the count here instead.
+            g_n_live_browsers--;
+            handle->client->set_on_gone(nullptr, nullptr);
+            handle->client = nullptr;
+            delete handle;
+            return nullptr;
+        }
+    }
+
+    return handle;
+}
+
+void wvcef_browser_destroy(struct wvcef_browser *browser) {
+    if (browser == nullptr) {
+        return;
+    }
+
+    // CEF keeps its own reference to the client until the browser is completely
+    // torn down, so this may not be the last one -- which is fine. The client stops
+    // calling out in OnBeforeClose, well before this runs.
+    browser->client = nullptr;
+    delete browser;
+}
+
+int wvcef_browser_get_id(struct wvcef_browser *browser) {
+    CefRefPtr<CefBrowser> b = browser_of(browser);
+    if (b == nullptr) {
+        return 0;
+    }
+    return b->GetIdentifier();
+}
+
+void wvcef_browser_close(struct wvcef_browser *browser) {
+    if (browser == nullptr || browser->client == nullptr || browser->close_requested) {
+        return;
+    }
+
+    browser->close_requested = true;
+
+    CefRefPtr<CefBrowser> b = browser->client->browser();
+    if (b != nullptr) {
+        b->GetHost()->CloseBrowser(true);
+    }
+}
+
+void wvcef_browser_load_url(struct wvcef_browser *browser, const char *url) {
+    CefRefPtr<CefBrowser> b = browser_of(browser);
+    if (b == nullptr || url == nullptr) {
+        return;
+    }
+    b->GetMainFrame()->LoadURL(CefString(url));
+}
+
+void wvcef_browser_reload(struct wvcef_browser *browser, bool ignore_cache) {
+    CefRefPtr<CefBrowser> b = browser_of(browser);
+    if (b == nullptr) {
+        return;
+    }
+    if (ignore_cache) {
+        b->ReloadIgnoreCache();
+    } else {
+        b->Reload();
+    }
+}
+
+void wvcef_browser_go_back(struct wvcef_browser *browser) {
+    CefRefPtr<CefBrowser> b = browser_of(browser);
+    if (b != nullptr && b->CanGoBack()) {
+        b->GoBack();
+    }
+}
+
+void wvcef_browser_go_forward(struct wvcef_browser *browser) {
+    CefRefPtr<CefBrowser> b = browser_of(browser);
+    if (b != nullptr && b->CanGoForward()) {
+        b->GoForward();
+    }
+}
+
+void wvcef_browser_execute_javascript(struct wvcef_browser *browser, const char *code) {
+    CefRefPtr<CefBrowser> b = browser_of(browser);
+    if (b == nullptr || code == nullptr) {
+        return;
+    }
+    CefRefPtr<CefFrame> frame = b->GetMainFrame();
+    frame->ExecuteJavaScript(CefString(code), frame->GetURL(), 0);
+}
+
+void wvcef_browser_resize(struct wvcef_browser *browser, int width, int height, double device_pixel_ratio) {
+    if (browser == nullptr || browser->client == nullptr) {
+        return;
+    }
+
+    browser->client->set_size(width > 0 ? width : 1, height > 0 ? height : 1, device_pixel_ratio > 0.0 ? device_pixel_ratio : 1.0);
+
+    CefRefPtr<CefBrowser> b = browser->client->browser();
+    if (b != nullptr) {
+        b->GetHost()->NotifyScreenInfoChanged();
+        b->GetHost()->WasResized();
+    }
+}
+
+void wvcef_browser_set_focus(struct wvcef_browser *browser, bool focused) {
+    CefRefPtr<CefBrowser> b = browser_of(browser);
+    if (b != nullptr) {
+        b->GetHost()->SetFocus(focused);
+    }
+}
+
+void wvcef_browser_send_mouse_move(struct wvcef_browser *browser, int x, int y, bool dragging) {
+    CefRefPtr<CefBrowser> b = browser_of(browser);
+    if (b == nullptr) {
+        return;
+    }
+
+    CefMouseEvent event;
+    event.x = x;
+    event.y = y;
+    event.modifiers = dragging ? EVENTFLAG_LEFT_MOUSE_BUTTON : EVENTFLAG_NONE;
+
+    b->GetHost()->SendMouseMoveEvent(event, false);
+}
+
+void wvcef_browser_send_mouse_click(struct wvcef_browser *browser, int x, int y, bool is_up) {
+    CefRefPtr<CefBrowser> b = browser_of(browser);
+    if (b == nullptr) {
+        return;
+    }
+
+    CefMouseEvent event;
+    event.x = x;
+    event.y = y;
+    event.modifiers = EVENTFLAG_LEFT_MOUSE_BUTTON;
+
+    if (!is_up) {
+        // Move there before pressing. A mouse always arrives via hover events, so
+        // the page already knows where the cursor is -- but a touchscreen has no
+        // hover, so the press would otherwise be the first the page hears of that
+        // position, and anything that resolves its target from the last move sees
+        // the press somewhere else entirely.
+        b->GetHost()->SendMouseMoveEvent(event, false);
+    }
+
+    b->GetHost()->SendMouseClickEvent(event, MBT_LEFT, is_up, 1);
+}
+
+void wvcef_browser_send_mouse_wheel(struct wvcef_browser *browser, int x, int y, int delta_x, int delta_y) {
+    CefRefPtr<CefBrowser> b = browser_of(browser);
+    if (b == nullptr) {
+        return;
+    }
+
+    CefMouseEvent event;
+    event.x = x;
+    event.y = y;
+    event.modifiers = EVENTFLAG_NONE;
+
+    // Flutter's scroll deltas grow downwards and are much finer grained than a
+    // mouse wheel click. Same conversion the webview_cef package applies on its
+    // non-Apple platforms, so scrolling feels identical.
+    b->GetHost()->SendMouseWheelEvent(event, delta_x * 10, -delta_y * 10);
+}
+
+namespace {
+
+/// CEF's "no range" sentinel, the same one cefclient uses for IME input.
+CefRange invalid_range() {
+    return CefRange(UINT32_MAX, UINT32_MAX);
+}
+
+}  // namespace
+
+void wvcef_browser_ime_commit_text(struct wvcef_browser *browser, const char *text) {
+    CefRefPtr<CefBrowser> b = browser_of(browser);
+    if (b == nullptr || text == nullptr) {
+        return;
+    }
+
+    b->GetHost()->ImeCommitText(CefString(text), invalid_range(), 0);
+}
+
+void wvcef_browser_ime_set_composition(struct wvcef_browser *browser, const char *text) {
+    CefRefPtr<CefBrowser> b = browser_of(browser);
+    if (b == nullptr || text == nullptr) {
+        return;
+    }
+
+    const CefString composition(text);
+    const std::vector<CefCompositionUnderline> underlines;
+    const uint32_t cursor = static_cast<uint32_t>(composition.length());
+
+    b->GetHost()->ImeSetComposition(composition, underlines, invalid_range(), CefRange(cursor, cursor));
+}

--- a/src/plugins/webview_cef/cef_bridge.h
+++ b/src/plugins/webview_cef/cef_bridge.h
@@ -1,0 +1,218 @@
+// SPDX-License-Identifier: MIT
+/*
+ * CEF bridge
+ *
+ * A plain-C ABI around the (C++) Chromium Embedded Framework API.
+ *
+ * The rest of flutter-pi is C, and flutter-pi's headers can't be included from
+ * C++ (platformchannel.h & friends use compound literals, which don't exist in
+ * C++). So all CEF-facing code lives in cef_bridge.cpp behind this header, and
+ * the plugin (plugin.c) only ever sees plain C types.
+ *
+ * Threading contract
+ * ------------------
+ * CEF runs its browser process message loop on a thread of its own
+ * (`multi_threaded_message_loop`), so CEF's "UI thread" is *not* flutter-pi's
+ * platform thread:
+ *
+ *   - wvcef_* functions may be called from any thread. CEF documents its browser
+ *     and browser-host methods as callable from any browser process thread, and
+ *     the one exception (creating a browser) is marshalled inside the bridge.
+ *   - callbacks in @ref wvcef_host_callbacks are invoked on CEF's UI thread, so
+ *     implementations must not touch flutter-pi state that isn't thread safe.
+ *
+ * A single @ref wvcef_browser handle is *not* internally serialised, though: the
+ * caller must not use one from two threads at once, and must not use it at all
+ * after passing it to @ref wvcef_browser_destroy. What a handle does tolerate is
+ * CEF closing the browser underneath it -- every call then becomes a no-op, so
+ * there is no window in which the caller has to have noticed yet.
+ *
+ * The other way round is tempting: CEF's `external_message_pump` makes the host's
+ * thread the UI thread, and then every callback can touch flutter-pi directly with
+ * no locks at all. It works until a Chromium task on the UI thread blocks waiting
+ * for more UI thread work -- a real message loop nests and delivers it, an external
+ * pump cannot, because the host is stuck inside its one CefDoMessageLoopWork() call
+ * and cannot re-enter it. The process then stops for good with the page still
+ * looking alive. A WebGL page reached that within seconds here, and CEF's own
+ * documentation recommends against the option. So: a real loop, and locks.
+ *
+ * Coordinate systems
+ * ------------------
+ * Everything crossing this boundary -- view size, pointer positions -- is in
+ * *logical* pixels, which is what flutter hands us. CEF works the same way:
+ * CefRenderHandler::GetViewRect is logical, and CEF multiplies it by the scale
+ * factor from GetScreenInfo to get the size of the pixel buffer it passes to
+ * OnPaint. So physical pixels only ever appear in on_paint().
+ *
+ * Copyright (c) 2026, Bojidar Tonchev <bojidar.tonchev@gmail.com>
+ */
+
+#ifndef _FLUTTERPI_SRC_PLUGINS_WEBVIEW_CEF_CEF_BRIDGE_H
+#define _FLUTTERPI_SRC_PLUGINS_WEBVIEW_CEF_CEF_BRIDGE_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct wvcef_browser;
+
+/**
+ * @brief Callbacks a webview instance delivers to the host (plugin.c).
+ *
+ * All of these are invoked on CEF's UI thread. Strings are only valid for the
+ * duration of the call. Every one of them may be NULL.
+ */
+struct wvcef_host_callbacks {
+    /**
+     * @brief A new frame was rendered.
+     *
+     * @param buffer BGRA8888 (byte order B,G,R,A), @ref width * @ref height * 4
+     *               bytes, tightly packed. Only valid during the call.
+     * @param width,height Size of the buffer in *physical* pixels.
+     */
+    void (*on_paint)(void *userdata, const void *buffer, int width, int height);
+
+    void (*on_load_start)(void *userdata, const char *url);
+    void (*on_load_end)(void *userdata, const char *url, int http_status_code);
+    void (*on_load_error)(void *userdata, int error_code, const char *error_text, const char *failed_url);
+
+    void (*on_url_changed)(void *userdata, const char *url);
+    void (*on_title_changed)(void *userdata, const char *title);
+    void (*on_tooltip)(void *userdata, const char *text);
+    void (*on_console_message)(void *userdata, int level, const char *message, const char *source, int line);
+
+    /// @param cursor_type a cef_cursor_type_t value.
+    void (*on_cursor_changed)(void *userdata, int cursor_type);
+
+    /// Called once the underlying browser is gone. The handle stays valid --
+    /// calls on it just stop doing anything -- until @ref wvcef_browser_destroy.
+    /// Note this arrives on CEF's UI thread, so a host that owns its handle from
+    /// somewhere else should hand the destroying over to that thread.
+    void (*on_closed)(void *userdata);
+};
+
+struct wvcef_init_options {
+    /// Absolute path of the CEF subprocess helper executable
+    /// (flutter-pi-cef-helper). Required.
+    const char *subprocess_path;
+
+    /// Directory containing icudtl.dat, *.pak and the *.bin snapshot files.
+    /// Required.
+    const char *resources_dir;
+
+    /// Directory containing the *.pak locale files. Usually
+    /// <resources_dir>/locales. Required.
+    const char *locales_dir;
+
+    /// Where Chromium may persist its cache. NULL/empty for a fully in-memory
+    /// ("incognito") profile.
+    const char *cache_path;
+
+    /// Overrides the User-Agent header. NULL to keep Chromium's default.
+    const char *user_agent;
+
+    /// Chromium log file, NULL for stderr.
+    const char *log_file;
+
+    /// 0 = default (warning), 1 = verbose, 2 = info, 3 = warning, 4 = error,
+    /// 5 = fatal, 99 = disable.
+    int log_severity;
+
+    /// Extra command line switches, written without the leading "--". A
+    /// "key=value" entry becomes a switch with a value, a bare "key" a boolean
+    /// switch.
+    const char *const *switches;
+    size_t n_switches;
+};
+
+/**
+ * @brief Entry point for the CEF helper (subprocess) executable.
+ *
+ * Returns the exit code the helper process should exit with, or -1 if this
+ * process is not a CEF subprocess.
+ */
+int wvcef_execute_subprocess(int argc, char **argv);
+
+/**
+ * @brief Initialize CEF and start the thread its message loop runs on.
+ *
+ * Call on the process's main thread: CEF installs signal handlers and forks its
+ * helper processes from here. Calling it more than once is a no-op.
+ *
+ * @returns 0 on success, an errno-style code otherwise.
+ */
+int wvcef_initialize(const struct wvcef_init_options *options);
+
+/// True if @ref wvcef_initialize succeeded and @ref wvcef_shutdown hasn't run yet.
+bool wvcef_is_initialized(void);
+
+/// Number of browsers that were created and haven't fully closed yet.
+int wvcef_n_live_browsers(void);
+
+/// Tears CEF down and joins its message loop thread. All browsers must have been
+/// closed before. Call on the main thread. CEF cannot be initialized again
+/// afterwards, in this process.
+void wvcef_shutdown(void);
+
+/**
+ * @brief Create an off-screen browser.
+ *
+ * @param width,height Size in logical pixels. The buffer delivered to on_paint
+ *                     is width*device_pixel_ratio by height*device_pixel_ratio.
+ * @param device_pixel_ratio Scale factor reported to the page (window.devicePixelRatio).
+ * @param frame_rate Maximum frames per second CEF will render, 1..60.
+ * @returns The browser, or NULL on failure.
+ */
+struct wvcef_browser *wvcef_browser_create(
+    const char *url,
+    int width,
+    int height,
+    double device_pixel_ratio,
+    int frame_rate,
+    const struct wvcef_host_callbacks *callbacks,
+    void *userdata
+);
+
+/// CEF's browser identifier, which is what the dart side of the webview_cef
+/// package uses to address a webview. 0 if the browser is already gone.
+int wvcef_browser_get_id(struct wvcef_browser *browser);
+
+/// Asks the browser to close. @ref wvcef_host_callbacks::on_closed is called once
+/// it's really gone.
+void wvcef_browser_close(struct wvcef_browser *browser);
+
+/// Releases the handle. Call it after @ref wvcef_host_callbacks::on_closed, from
+/// whichever thread owns the handle. The handle must not be used afterwards.
+void wvcef_browser_destroy(struct wvcef_browser *browser);
+
+void wvcef_browser_load_url(struct wvcef_browser *browser, const char *url);
+void wvcef_browser_reload(struct wvcef_browser *browser, bool ignore_cache);
+void wvcef_browser_go_back(struct wvcef_browser *browser);
+void wvcef_browser_go_forward(struct wvcef_browser *browser);
+void wvcef_browser_execute_javascript(struct wvcef_browser *browser, const char *code);
+
+/// Resize the off-screen surface. Sizes are in logical pixels.
+void wvcef_browser_resize(struct wvcef_browser *browser, int width, int height, double device_pixel_ratio);
+
+void wvcef_browser_set_focus(struct wvcef_browser *browser, bool focused);
+
+/// Feeds UTF-8 text to whatever has focus in the page. This is how the
+/// webview_cef dart side delivers typed text.
+void wvcef_browser_ime_commit_text(struct wvcef_browser *browser, const char *text);
+void wvcef_browser_ime_set_composition(struct wvcef_browser *browser, const char *text);
+
+/// Coordinates are in logical pixels, relative to the webview's top left corner.
+/// @param dragging true to report the left button as held down.
+void wvcef_browser_send_mouse_move(struct wvcef_browser *browser, int x, int y, bool dragging);
+void wvcef_browser_send_mouse_click(struct wvcef_browser *browser, int x, int y, bool is_up);
+void wvcef_browser_send_mouse_wheel(struct wvcef_browser *browser, int x, int y, int delta_x, int delta_y);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // _FLUTTERPI_SRC_PLUGINS_WEBVIEW_CEF_CEF_BRIDGE_H

--- a/src/plugins/webview_cef/helper_main.cpp
+++ b/src/plugins/webview_cef/helper_main.cpp
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: MIT
+/*
+ * CEF subprocess helper
+ *
+ * Chromium is multi-process: the browser process (flutter-pi) spawns a zygote,
+ * a GPU process and one renderer per site. On Linux those subprocesses are
+ * launched by re-executing a binary, which is why they get their own tiny
+ * executable instead of re-entering flutter-pi's main() -- a renderer that
+ * accidentally booted a whole flutter engine would be a bad day.
+ *
+ * flutter-pi points CefSettings::browser_subprocess_path at this binary.
+ *
+ * Copyright (c) 2026, Bojidar Tonchev <bojidar.tonchev@gmail.com>
+ */
+
+#include "cef_bridge.h"
+
+int main(int argc, char **argv) {
+    const int exit_code = wvcef_execute_subprocess(argc, argv);
+
+    // CefExecuteProcess returns -1 when the process isn't a CEF subprocess at
+    // all, which for this binary means somebody ran it by hand.
+    if (exit_code < 0) {
+        return 1;
+    }
+
+    return exit_code;
+}

--- a/src/plugins/webview_cef/plugin.c
+++ b/src/plugins/webview_cef/plugin.c
@@ -1,0 +1,1365 @@
+// SPDX-License-Identifier: MIT
+/*
+ * CEF powered webview plugin
+ *
+ * The flutter-pi side of the webview: speaks the `webview_cef` pub package's
+ * platform channel and turns the BGRA frames CEF renders off-screen into flutter
+ * external textures.
+ *
+ * Two threads meet in here:
+ *   - platform channel handlers run on flutter-pi's platform thread,
+ *   - every cef_bridge callback runs on CEF's own UI thread (see cef_bridge.h for
+ *     why CEF owns that thread rather than borrowing ours).
+ *
+ * So the webview list is only ever touched from the platform thread -- anything
+ * arriving from CEF that has to change it is posted there -- and everything a
+ * frame touches on its way to a texture is behind @ref webview_cef_plugin::gl_mutex.
+ * Sending a platform message is the one thing safe to do from either thread:
+ * flutterpi_send_platform_message posts to the platform thread when it isn't
+ * already on it.
+ *
+ * Copyright (c) 2026, Bojidar Tonchev <bojidar.tonchev@gmail.com>
+ */
+
+#define _GNU_SOURCE
+
+#include <errno.h>
+#include <inttypes.h>
+#include <limits.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+#include <pthread.h>
+
+#include "flutter-pi.h"
+#include "platformchannel.h"
+#include "pluginregistry.h"
+#include "texture_registry.h"
+#include "util/logging.h"
+
+#include "config.h"
+
+#ifndef HAVE_EGL_GLES2
+    #error "The webview_cef plugin requires EGL/OpenGL ES support."
+#endif
+
+#include "gl_renderer.h"
+#include "gles.h"
+#include "plugins/webview_cef.h"
+#include "plugins/webview_cef/cef_bridge.h"
+
+/// Where the CEF runtime files (libcef.so, icudtl.dat, *.pak, *.bin, locales/)
+/// were installed. Overridable at configure time and at runtime, see
+/// resolve_env() below.
+#ifndef WEBVIEW_CEF_RUNTIME_DIR
+    #define WEBVIEW_CEF_RUNTIME_DIR "/usr/lib/cef"
+#endif
+
+/// The CEF subprocess helper executable.
+#ifndef WEBVIEW_CEF_HELPER_PATH
+    #define WEBVIEW_CEF_HELPER_PATH "/usr/bin/flutter-pi-cef-helper"
+#endif
+
+#define MAX_SWITCHES 64
+#define DEFAULT_FRAME_RATE 30
+
+/// CEF clamps `windowless_frame_rate` to this range.
+#define MIN_FRAME_RATE 1
+#define MAX_FRAME_RATE 60
+
+/// Traces the browser and frame lifecycle when FLUTTERPI_CEF_TRACE is set.
+///
+/// Deliberately not LOG_DEBUG: that is compiled out unless flutter-pi itself was
+/// built with DEBUG, and a webview that comes up blank is something you have to
+/// explain on a release image, in place, without a rebuild.
+#define TRACE(...)                                         \
+    do {                                                   \
+        if (plugin.trace_level >= 1) {                     \
+            fprintf(stderr, "[webview_cef] " __VA_ARGS__); \
+        }                                                  \
+    } while (0)
+
+/// FLUTTERPI_CEF_TRACE=2: every frame, step by step, unbuffered.
+///
+/// This exists to find out where a frame stopped, on a device with no debugger and
+/// no package feed to put one on. Each step of the upload can block -- taking
+/// gl_mutex, making the context current, glFinish -- and which one matters, so the
+/// last line printed names the call that didn't come back.
+#define TRACE2(...)                                        \
+    do {                                                   \
+        if (plugin.trace_level >= 2) {                     \
+            fprintf(stderr, "[webview_cef] " __VA_ARGS__); \
+            fflush(stderr);                                \
+        }                                                  \
+    } while (0)
+
+/// Chromium switches we pass unless FLUTTERPI_CEF_NO_DEFAULT_SWITCHES is set.
+static const char *const default_switches[] = {
+    // There is no X server and no wayland compositor to talk to, so Chromium has
+    // to use the headless ozone platform.
+    "ozone-platform=headless",
+
+    // Render through ANGLE on native EGL/GLES, which on a KMS target means Mesa
+    // on a render node -- /dev/dri/renderD128 needs no DRM master, so Chromium
+    // gets the GPU while flutter-pi keeps card0.
+    //
+    // Worth being explicit about why this matters, because the failure is silent
+    // and expensive: left to itself Chromium ends up on SwiftShader and
+    // rasterises WebGL on the CPU. Measured on a Celeron J6412, a WebGL slot
+    // game ran at about 3fps with SwiftShader's four worker threads saturating
+    // all four cores, against ~3% CPU in the GPU process once Mesa's iris driver
+    // was actually being used. Nothing in the page or the plugin looks wrong
+    // either way -- it just renders slowly.
+    //
+    // Necessary but not sufficient: see the EGL_PLATFORM note in
+    // ensure_cef_initialized(), without which Mesa goes looking for an X display,
+    // fails, and Chromium quietly falls back to SwiftShader anyway.
+    "use-gl=angle",
+    "use-angle=gl-egl",
+
+    // An embedded GPU won't be on Chromium's list of known-good configurations,
+    // and being absent from that list is not the same as being broken.
+    "ignore-gpu-blocklist",
+
+    // Only reached if the native EGL above doesn't come up -- no GL driver, no
+    // render node. Chromium has refused software WebGL on its own since around
+    // M120, so without this flag the fallback isn't "slow WebGL", it is a page
+    // that loads completely and draws nothing. The "unsafe" is about running
+    // untrusted shaders through a software rasteriser; a kiosk pointed at a known
+    // page is the trusted case the flag exists for.
+    "enable-unsafe-swiftshader",
+
+    "disable-dev-shm-usage",
+    "autoplay-policy=no-user-gesture-required",
+};
+
+struct webview {
+    struct webview *next;
+
+    struct texture *texture;
+    int64_t texture_id;
+
+    /// CEF's browser identifier. This is what the dart side addresses us by.
+    int browser_id;
+
+    struct wvcef_browser *browser;
+
+    /// Logical size & scale, as last reported by `setSize`.
+    int logical_width, logical_height;
+    double pixel_ratio;
+
+    /// The GL texture the CEF frames are uploaded into. Kept for the lifetime of
+    /// the webview and re-uploaded in place on every frame.
+    GLuint gl_texture;
+    int tex_width, tex_height;
+
+    /// Only used if the driver can't take BGRA pixels directly.
+    uint8_t *swizzle_buffer;
+    size_t swizzle_buffer_size;
+
+    /// Frames CEF has handed us, for TRACE only.
+    uint64_t n_frames;
+
+    /// `close` was called; the webview is torn down but still waiting for CEF to
+    /// confirm the browser is gone.
+    bool closing;
+};
+
+struct webview_cef_plugin {
+    struct flutterpi *flutterpi;
+
+    EGLDisplay egl_display;
+    EGLContext egl_context;
+    bool supports_bgra;
+
+    /// FLUTTERPI_CEF_TRACE; see TRACE and TRACE2 above.
+    int trace_level;
+
+    /// Guards the EGL context and every webview's texture state.
+    ///
+    /// Frames arrive on CEF's UI thread while the platform thread may be
+    /// tearing the same webview down, and the plugin's EGL context is made
+    /// current and released within each use, so it is shareable between threads
+    /// -- but only one at a time.
+    pthread_mutex_t gl_mutex;
+
+    struct webview *webviews;
+};
+
+/// There's one webview plugin per process, and both the platform channel
+/// receiver and the CEF callbacks need to reach it, so it's a file-scope
+/// singleton rather than something passed around as userdata.
+static struct webview_cef_plugin plugin;
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+static const char *resolve_env(const char *env_name, const char *fallback) {
+    const char *env = getenv(env_name);
+
+    if (env != NULL && env[0] != '\0') {
+        return env;
+    }
+
+    return fallback;
+}
+
+static long resolve_env_long(const char *env_name, long fallback) {
+    const char *env = getenv(env_name);
+    char *end;
+    long value;
+
+    if (env == NULL || env[0] == '\0') {
+        return fallback;
+    }
+
+    errno = 0;
+    value = strtol(env, &end, 10);
+    if (errno != 0 || end == env || *end != '\0') {
+        LOG_ERROR("Ignoring %s: \"%s\" is not a number.\n", env_name, env);
+        return fallback;
+    }
+
+    return value;
+}
+
+/// `windowless_frame_rate` for new browsers.
+static long resolve_frame_rate(void) {
+    long frame_rate = resolve_env_long("FLUTTERPI_CEF_FRAME_RATE", DEFAULT_FRAME_RATE);
+
+    if (frame_rate < MIN_FRAME_RATE) {
+        return MIN_FRAME_RATE;
+    }
+    if (frame_rate > MAX_FRAME_RATE) {
+        return MAX_FRAME_RATE;
+    }
+    return frame_rate;
+}
+
+/// The webview_cef dart side passes arguments as a positional list, or as a bare
+/// value for the single-argument methods.
+static struct std_value *arg_at(struct std_value *args, size_t index) {
+    if (args == NULL || !STDVALUE_IS_LIST(*args) || index >= args->size) {
+        return NULL;
+    }
+    return args->list + index;
+}
+
+static bool arg_int_at(struct std_value *args, size_t index, int64_t *out) {
+    struct std_value *value = arg_at(args, index);
+
+    if (value == NULL || !STDVALUE_IS_INT(*value)) {
+        return false;
+    }
+
+    *out = STDVALUE_AS_INT(*value);
+    return true;
+}
+
+static bool arg_num_at(struct std_value *args, size_t index, double *out) {
+    struct std_value *value = arg_at(args, index);
+
+    if (value == NULL || !STDVALUE_IS_NUM(*value)) {
+        return false;
+    }
+
+    *out = (double) STDVALUE_AS_NUM(*value);
+    return true;
+}
+
+static const char *arg_string_at(struct std_value *args, size_t index) {
+    struct std_value *value = arg_at(args, index);
+
+    if (value == NULL || !STDVALUE_IS_STRING(*value)) {
+        return NULL;
+    }
+
+    return STDVALUE_AS_STRING(*value);
+}
+
+static bool arg_bool_at(struct std_value *args, size_t index, bool *out) {
+    struct std_value *value = arg_at(args, index);
+
+    if (value == NULL || !STDVALUE_IS_BOOL(*value)) {
+        return false;
+    }
+
+    *out = STDVALUE_AS_BOOL(*value);
+    return true;
+}
+
+static struct webview *webview_find(int browser_id) {
+    for (struct webview *wv = plugin.webviews; wv != NULL; wv = wv->next) {
+        if (wv->browser_id == browser_id) {
+            return wv;
+        }
+    }
+    return NULL;
+}
+
+static void webview_list_add(struct webview *wv) {
+    wv->next = plugin.webviews;
+    plugin.webviews = wv;
+}
+
+static void webview_list_remove(struct webview *wv) {
+    struct webview **slot = &plugin.webviews;
+
+    while (*slot != NULL) {
+        if (*slot == wv) {
+            *slot = wv->next;
+            return;
+        }
+        slot = &(*slot)->next;
+    }
+}
+
+static void webview_free(struct webview *wv) {
+    webview_list_remove(wv);
+    free(wv->swizzle_buffer);
+    free(wv);
+}
+
+/// Releases the flutter texture and the GL texture. Safe to call twice.
+///
+/// Platform thread. Takes gl_mutex because a frame may be arriving on CEF's UI
+/// thread at the same moment, and it must not find a half-released webview or the
+/// EGL context current on another thread.
+static void webview_release_textures(struct webview *wv) {
+    pthread_mutex_lock(&plugin.gl_mutex);
+
+    if (wv->texture != NULL) {
+        texture_destroy(wv->texture);
+        wv->texture = NULL;
+    }
+
+    if (wv->gl_texture != 0) {
+        if (eglMakeCurrent(plugin.egl_display, EGL_NO_SURFACE, EGL_NO_SURFACE, plugin.egl_context) == EGL_TRUE) {
+            glDeleteTextures(1, &wv->gl_texture);
+            eglMakeCurrent(plugin.egl_display, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
+        } else {
+            LOG_ERROR("Could not make the webview EGL context current to delete a texture. eglMakeCurrent: 0x%04X\n", eglGetError());
+        }
+        wv->gl_texture = 0;
+    }
+
+    pthread_mutex_unlock(&plugin.gl_mutex);
+}
+
+// ---------------------------------------------------------------------------
+// frame upload
+// ---------------------------------------------------------------------------
+
+static void on_texture_frame_destroy(const struct texture_frame *frame, void *userdata) {
+    // The GL texture belongs to the webview and is reused for every frame, so
+    // there is nothing to release per frame.
+    (void) frame;
+    (void) userdata;
+}
+
+/// Converts BGRA to RGBA into a scratch buffer, for drivers without
+/// GL_EXT_texture_format_BGRA8888.
+static const void *swizzle_bgra_to_rgba(struct webview *wv, const void *buffer, int width, int height) {
+    const uint8_t *src;
+    uint8_t *dst;
+    size_t n_pixels, needed;
+
+    n_pixels = (size_t) width * (size_t) height;
+    needed = n_pixels * 4;
+
+    if (wv->swizzle_buffer_size < needed) {
+        uint8_t *new_buffer = realloc(wv->swizzle_buffer, needed);
+        if (new_buffer == NULL) {
+            return NULL;
+        }
+        wv->swizzle_buffer = new_buffer;
+        wv->swizzle_buffer_size = needed;
+    }
+
+    src = buffer;
+    dst = wv->swizzle_buffer;
+
+    for (size_t i = 0; i < n_pixels; i++) {
+        dst[i * 4 + 0] = src[i * 4 + 2];
+        dst[i * 4 + 1] = src[i * 4 + 1];
+        dst[i * 4 + 2] = src[i * 4 + 0];
+        dst[i * 4 + 3] = src[i * 4 + 3];
+    }
+
+    return dst;
+}
+
+/// A frame from CEF, on CEF's UI thread.
+///
+/// Everything from here to texture_push_frame runs under gl_mutex: the platform
+/// thread may be releasing this very webview's textures, and the plugin's EGL
+/// context can only be current on one thread at a time.
+static void on_paint(void *userdata, const void *buffer, int width, int height) {
+    struct webview *wv;
+    const void *pixels;
+    GLenum gl_format, gl_error;
+    EGLBoolean egl_ok;
+    bool uploaded = false;
+
+    wv = userdata;
+
+    wv->n_frames++;
+
+    pthread_mutex_lock(&plugin.gl_mutex);
+
+    // The first frames are what you want to see; after that a heartbeat is enough,
+    // since 30fps of this would drown out everything else. Under the lock because
+    // of wv->texture, which the platform thread clears from under us on close.
+    if (wv->n_frames <= 3 || wv->n_frames % 100 == 0) {
+        TRACE(
+            "paint %" PRIu64 ": browser %d, %dx%d px, texture %" PRId64 "%s\n",
+            wv->n_frames,
+            wv->browser_id,
+            width,
+            height,
+            wv->texture_id,
+            wv->texture == NULL ? " -- DROPPED, no texture" : ""
+        );
+    }
+
+    // Closed while a frame was in flight.
+    if (wv->texture == NULL || width <= 0 || height <= 0) {
+        pthread_mutex_unlock(&plugin.gl_mutex);
+        return;
+    }
+
+    if (plugin.supports_bgra) {
+        gl_format = GL_BGRA_EXT;
+        pixels = buffer;
+    } else {
+        gl_format = GL_RGBA;
+        pixels = swizzle_bgra_to_rgba(wv, buffer, width, height);
+        if (pixels == NULL) {
+            LOG_ERROR("Out of memory while converting a webview frame.\n");
+            pthread_mutex_unlock(&plugin.gl_mutex);
+            return;
+        }
+    }
+
+    TRACE2("paint %" PRIu64 ": making context current\n", wv->n_frames);
+
+    egl_ok = eglMakeCurrent(plugin.egl_display, EGL_NO_SURFACE, EGL_NO_SURFACE, plugin.egl_context);
+    if (egl_ok == EGL_FALSE) {
+        LOG_ERROR("Could not make the webview EGL context current. eglMakeCurrent: 0x%04X\n", eglGetError());
+        pthread_mutex_unlock(&plugin.gl_mutex);
+        return;
+    }
+
+    TRACE2("paint %" PRIu64 ": context current, uploading %dx%d\n", wv->n_frames, width, height);
+
+    if (wv->gl_texture == 0) {
+        glGenTextures(1, &wv->gl_texture);
+        if (wv->gl_texture == 0) {
+            LOG_ERROR("Could not create a GL texture for the webview. glGenTextures: 0x%04X\n", glGetError());
+            goto clear_context;
+        }
+
+        glBindTexture(GL_TEXTURE_2D, wv->gl_texture);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+
+        wv->tex_width = 0;
+        wv->tex_height = 0;
+    } else {
+        glBindTexture(GL_TEXTURE_2D, wv->gl_texture);
+    }
+
+    if (wv->tex_width != width || wv->tex_height != height) {
+        glTexImage2D(GL_TEXTURE_2D, 0, gl_format, width, height, 0, gl_format, GL_UNSIGNED_BYTE, pixels);
+
+        gl_error = glGetError();
+        if (gl_error != GL_NO_ERROR) {
+            LOG_ERROR("Could not allocate the webview GL texture. glTexImage2D: 0x%04X\n", gl_error);
+            glBindTexture(GL_TEXTURE_2D, 0);
+            goto clear_context;
+        }
+
+        wv->tex_width = width;
+        wv->tex_height = height;
+    } else {
+        glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, width, height, gl_format, GL_UNSIGNED_BYTE, pixels);
+
+        gl_error = glGetError();
+        if (gl_error != GL_NO_ERROR) {
+            LOG_ERROR("Could not upload a webview frame. glTexSubImage2D: 0x%04X\n", gl_error);
+            glBindTexture(GL_TEXTURE_2D, 0);
+            goto clear_context;
+        }
+    }
+
+    glBindTexture(GL_TEXTURE_2D, 0);
+
+    // The flutter rasterizer samples this texture from a different thread and a
+    // different (shared) context, so the upload has to be complete before we
+    // hand the frame over. glFlush() is the minimum the GLES spec asks for, but
+    // in practice only glFinish() is reliable across drivers. If this ever shows
+    // up in a profile, an EGL fence sync is the way to relax it.
+    TRACE2("paint %" PRIu64 ": uploaded, glFinish\n", wv->n_frames);
+    glFinish();
+    TRACE2("paint %" PRIu64 ": glFinish returned\n", wv->n_frames);
+    uploaded = true;
+
+clear_context:
+    eglMakeCurrent(plugin.egl_display, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
+
+    if (!uploaded) {
+        pthread_mutex_unlock(&plugin.gl_mutex);
+        return;
+    }
+
+    TRACE2("paint %" PRIu64 ": pushing frame\n", wv->n_frames);
+
+    texture_push_frame(
+        wv->texture,
+        &(struct texture_frame){
+            .gl = {
+                .target = GL_TEXTURE_2D,
+                .name = wv->gl_texture,
+                .format = GL_RGBA8_OES,
+                .width = (size_t) width,
+                .height = (size_t) height,
+            },
+            .destroy = on_texture_frame_destroy,
+            .userdata = NULL,
+        }
+    );
+
+    pthread_mutex_unlock(&plugin.gl_mutex);
+}
+
+// ---------------------------------------------------------------------------
+// events towards dart
+//
+// The webview_cef dart side keys everything off the CEF browser id and reads the
+// arguments out of a map.
+//
+// These all run on CEF's UI thread. That is fine because they pass no response
+// callback: platch_send then only encodes into a local buffer and hands it to
+// flutterpi_send_platform_message, which copies the message and posts it to the
+// platform thread. Passing a callback would take platch_send's response-handle
+// path instead, which is documented as not working off the platform thread.
+// ---------------------------------------------------------------------------
+
+static void send_event(int browser_id, const char *method, struct std_value *extra_keys, struct std_value *extra_values, size_t n_extra) {
+    struct std_value keys[6];
+    struct std_value values[6];
+    struct std_value event;
+
+    if (n_extra > 5) {
+        n_extra = 5;
+    }
+
+    keys[0] = STDSTRING("browserId");
+    values[0] = STDINT32(browser_id);
+
+    for (size_t i = 0; i < n_extra; i++) {
+        keys[i + 1] = extra_keys[i];
+        values[i + 1] = extra_values[i];
+    }
+
+    event.type = kStdMap;
+    event.size = n_extra + 1;
+    event.keys = keys;
+    event.values = values;
+
+    platch_call_std(WEBVIEW_CEF_CHANNEL, (char *) method, &event, NULL, NULL);
+}
+
+static void send_string_event(int browser_id, const char *method, const char *key, const char *value) {
+    struct std_value keys[1] = { STDSTRING((char *) key) };
+    struct std_value values[1] = { STDSTRING((char *) (value != NULL ? value : "")) };
+
+    send_event(browser_id, method, keys, values, 1);
+}
+
+static void on_url_changed(void *userdata, const char *url) {
+    struct webview *wv = userdata;
+    send_string_event(wv->browser_id, "urlChanged", "url", url);
+}
+
+static void on_title_changed(void *userdata, const char *title) {
+    struct webview *wv = userdata;
+    send_string_event(wv->browser_id, "titleChanged", "title", title);
+}
+
+static void on_tooltip(void *userdata, const char *text) {
+    struct webview *wv = userdata;
+    send_string_event(wv->browser_id, "onTooltip", "text", text);
+}
+
+static void on_load_start(void *userdata, const char *url) {
+    struct webview *wv = userdata;
+    // The dart side really does call this key "urlId".
+    send_string_event(wv->browser_id, "onLoadStart", "urlId", url);
+}
+
+static void on_load_end(void *userdata, const char *url, int http_status_code) {
+    struct webview *wv = userdata;
+
+    (void) http_status_code;
+    send_string_event(wv->browser_id, "onLoadEnd", "urlId", url);
+}
+
+static void on_load_error(void *userdata, int error_code, const char *error_text, const char *failed_url) {
+    struct webview *wv = userdata;
+
+    // The webview_cef dart API has no load error callback, so this is only
+    // useful in the log. CEF still calls OnLoadEnd afterwards, which the app
+    // does see.
+    LOG_ERROR(
+        "Webview %d could not load %s: %s (%d)\n",
+        wv->browser_id,
+        failed_url != NULL ? failed_url : "(?)",
+        error_text != NULL ? error_text : "(?)",
+        error_code
+    );
+}
+
+static void on_cursor_changed(void *userdata, int cursor_type) {
+    struct webview *wv = userdata;
+
+    struct std_value keys[1] = { STDSTRING("type") };
+    struct std_value values[1] = { STDINT32(cursor_type) };
+
+    send_event(wv->browser_id, "onCursorChanged", keys, values, 1);
+}
+
+static void on_console_message(void *userdata, int level, const char *message, const char *source, int line) {
+    struct webview *wv = userdata;
+
+    struct std_value keys[4] = { STDSTRING("level"), STDSTRING("message"), STDSTRING("source"), STDSTRING("line") };
+    struct std_value values[4] = {
+        STDINT32(level),
+        STDSTRING((char *) (message != NULL ? message : "")),
+        STDSTRING((char *) (source != NULL ? source : "")),
+        STDINT32(line),
+    };
+
+    send_event(wv->browser_id, "onConsoleMessage", keys, values, 4);
+}
+
+/// The browser is really gone now, so the webview can be freed. Runs on the
+/// platform thread, posted by on_browser_closed.
+static int on_browser_closed_on_platform(void *userdata) {
+    struct webview *wv = userdata;
+
+    // Releasing the handle is this thread's job precisely because this thread is
+    // the only one that reads wv->browser: doing it back on CEF's thread would
+    // invalidate the pointer under whatever channel call happens to be in flight.
+    if (wv->browser != NULL) {
+        wvcef_browser_destroy(wv->browser);
+        wv->browser = NULL;
+    }
+
+    if (!wv->closing) {
+        // CEF closed the browser on its own -- a crashed renderer, most likely.
+        // Keep the texture around showing the last frame; the dart side still
+        // holds a controller for it and would only get a black rectangle
+        // otherwise.
+        LOG_ERROR("Webview %d was closed by CEF.\n", wv->browser_id);
+        return 0;
+    }
+
+    webview_free(wv);
+    return 0;
+}
+
+/// CEF's UI thread, from inside the browser's own teardown.
+///
+/// Everything this has to touch -- the webview list, wv->browser, the webview
+/// itself -- belongs to the platform thread, so nothing is done here beyond
+/// getting the work over there. The webview stays readable until then; the
+/// bridge has already made every call on the handle a no-op.
+static void on_browser_closed(void *userdata) {
+    struct webview *wv = userdata;
+    int ok;
+
+    ok = flutterpi_post_platform_task(on_browser_closed_on_platform, wv);
+    if (ok != 0) {
+        // Nothing sane left to do: freeing it here would race the platform
+        // thread, so leak it and say so.
+        LOG_ERROR("Could not post webview teardown to the platform thread: %s\n", strerror(ok));
+    }
+}
+
+static const struct wvcef_host_callbacks host_callbacks = {
+    .on_paint = on_paint,
+    .on_load_start = on_load_start,
+    .on_load_end = on_load_end,
+    .on_load_error = on_load_error,
+    .on_url_changed = on_url_changed,
+    .on_title_changed = on_title_changed,
+    .on_tooltip = on_tooltip,
+    .on_console_message = on_console_message,
+    .on_cursor_changed = on_cursor_changed,
+    .on_closed = on_browser_closed,
+};
+
+// ---------------------------------------------------------------------------
+// CEF initialization
+// ---------------------------------------------------------------------------
+
+/// Splits a comma separated switch list into `switches`, writing into `list`
+/// (which is modified in place). Returns the new switch count.
+static size_t parse_switch_list(char *list, const char **switches, size_t n_switches, size_t max_switches) {
+    char *cursor = list;
+
+    while (cursor != NULL && *cursor != '\0' && n_switches < max_switches) {
+        char *comma = strchr(cursor, ',');
+
+        if (comma != NULL) {
+            *comma = '\0';
+        }
+
+        if (*cursor != '\0') {
+            switches[n_switches++] = cursor;
+        }
+
+        cursor = comma != NULL ? comma + 1 : NULL;
+    }
+
+    return n_switches;
+}
+
+/**
+ * @brief Starts CEF, if it isn't running yet.
+ *
+ * The webview_cef channel only carries a user agent, so everything else is
+ * configured through the environment -- see the README.
+ */
+static int ensure_cef_initialized(const char *user_agent) {
+    struct wvcef_init_options options;
+    const char *switches[MAX_SWITCHES];
+    char *env_switches_copy = NULL;
+    char locales_dir[PATH_MAX];
+    const char *runtime_dir;
+    const char *env_switches;
+    size_t n_switches = 0;
+    int written;
+    int ok;
+
+    if (wvcef_is_initialized()) {
+        return 0;
+    }
+
+    memset(&options, 0, sizeof options);
+
+    runtime_dir = resolve_env("FLUTTERPI_CEF_RUNTIME_DIR", WEBVIEW_CEF_RUNTIME_DIR);
+
+    written = snprintf(locales_dir, sizeof(locales_dir), "%s/locales", runtime_dir);
+    if (written < 0 || (size_t) written >= sizeof(locales_dir)) {
+        LOG_ERROR("The CEF runtime directory path is too long: %s\n", runtime_dir);
+        return ENAMETOOLONG;
+    }
+
+    options.subprocess_path = resolve_env("FLUTTERPI_CEF_HELPER", WEBVIEW_CEF_HELPER_PATH);
+    // The resources sit in the runtime directory itself, so there is nothing to
+    // build here and nothing to copy.
+    options.resources_dir = runtime_dir;
+    options.locales_dir = locales_dir;
+    options.cache_path = resolve_env("FLUTTERPI_CEF_CACHE_PATH", NULL);
+    options.user_agent = user_agent;
+    options.log_file = resolve_env("FLUTTERPI_CEF_LOG_FILE", NULL);
+    options.log_severity = (int) resolve_env_long("FLUTTERPI_CEF_LOG_SEVERITY", 0);
+
+    if (getenv("FLUTTERPI_CEF_NO_DEFAULT_SWITCHES") == NULL) {
+        for (size_t i = 0; i < ARRAY_SIZE(default_switches) && n_switches < MAX_SWITCHES; i++) {
+            switches[n_switches++] = default_switches[i];
+        }
+    }
+
+    // FLUTTERPI_CEF_SWITCHES=disable-web-security,enable-logging=stderr
+    env_switches = getenv("FLUTTERPI_CEF_SWITCHES");
+    if (env_switches != NULL && env_switches[0] != '\0') {
+        env_switches_copy = strdup(env_switches);
+        if (env_switches_copy != NULL) {
+            n_switches = parse_switch_list(env_switches_copy, switches, n_switches, MAX_SWITCHES);
+        }
+    }
+
+    options.switches = switches;
+    options.n_switches = n_switches;
+
+    // Mesa's EGL defaults to the X11 platform, and there is no X server here. The
+    // CEF helper processes then fail eglInitialize with "Could not open the default
+    // X display" and Chromium falls back to SwiftShader, saying so nowhere except
+    // its own log -- so `use-gl=angle` above only reaches the GPU with this set.
+    //
+    // It goes in *our* environment because CEF has no hook for a subprocess's: the
+    // helpers are forked from this process and inherit it. flutter-pi's own display
+    // is not affected. It already exists by the time any plugin is initialized, and
+    // it is created with an explicit platform -- eglGetPlatformDisplay with
+    // EGL_PLATFORM_GBM_KHR -- which EGL_PLATFORM does not override; the variable
+    // only steers the legacy eglGetDisplay().
+    //
+    // Not overwritten, so a target that wants a different EGL platform (or plain
+    // X11, if someone runs this under one) can just say so in the environment.
+    setenv("EGL_PLATFORM", "surfaceless", 0);
+
+    LOG_DEBUG("Initializing CEF. runtime dir: %s, helper: %s\n", runtime_dir, options.subprocess_path);
+
+    ok = wvcef_initialize(&options);
+
+    free(env_switches_copy);
+
+    if (ok != 0) {
+        return ok;
+    }
+
+    return 0;
+}
+
+// ---------------------------------------------------------------------------
+// method handlers
+// ---------------------------------------------------------------------------
+
+/// `init` takes the user agent directly, or nothing at all.
+static int on_init(struct std_value *args, FlutterPlatformMessageResponseHandle *response_handle) {
+    const char *user_agent = NULL;
+    int ok;
+
+    if (args != NULL && STDVALUE_IS_STRING(*args)) {
+        user_agent = STDVALUE_AS_STRING(*args);
+    }
+
+    ok = ensure_cef_initialized(user_agent);
+    if (ok != 0) {
+        return platch_respond_error_std(response_handle, "cef-init-failed", "Could not initialize CEF. See the flutter-pi log.", &STDNULL);
+    }
+
+    return platch_respond_success_std(response_handle, &STDNULL);
+}
+
+/// `create` takes the url directly and answers with [browserId, textureId].
+static int on_create(struct std_value *args, FlutterPlatformMessageResponseHandle *response_handle) {
+    struct webview *wv;
+    const char *url = NULL;
+    long frame_rate;
+    int ok;
+
+    ok = ensure_cef_initialized(NULL);
+    if (ok != 0) {
+        return platch_respond_error_std(response_handle, "cef-init-failed", "Could not initialize CEF. See the flutter-pi log.", &STDNULL);
+    }
+
+    if (args != NULL && STDVALUE_IS_STRING(*args)) {
+        url = STDVALUE_AS_STRING(*args);
+    }
+
+    frame_rate = resolve_frame_rate();
+
+    wv = calloc(1, sizeof *wv);
+    if (wv == NULL) {
+        return platch_respond_native_error_std(response_handle, ENOMEM);
+    }
+
+    // The dart side doesn't know the widget size yet at this point -- it calls
+    // `setSize` once the webview has been laid out. Until then CEF renders at
+    // the smallest size it accepts.
+    wv->logical_width = 1;
+    wv->logical_height = 1;
+    wv->pixel_ratio = 1.0;
+
+    wv->texture = flutterpi_create_texture(plugin.flutterpi);
+    if (wv->texture == NULL) {
+        free(wv);
+        return platch_respond_error_std(response_handle, "texture-failed", "Could not create a flutter texture.", &STDNULL);
+    }
+
+    wv->texture_id = texture_get_id(wv->texture);
+
+    wv->browser = wvcef_browser_create(url, wv->logical_width, wv->logical_height, wv->pixel_ratio, (int) frame_rate, &host_callbacks, wv);
+    if (wv->browser == NULL) {
+        // Not logged as well: the bridge has already said why on its way out, and
+        // the dart side is being told right here.
+        texture_destroy(wv->texture);
+        free(wv);
+        return platch_respond_error_std(response_handle, "browser-failed", "Could not create the CEF browser.", &STDNULL);
+    }
+
+    wv->browser_id = wvcef_browser_get_id(wv->browser);
+    webview_list_add(wv);
+
+    TRACE("created: browser %d, texture %" PRId64 ", url %s\n", wv->browser_id, wv->texture_id, url != NULL ? url : "about:blank");
+
+    return platch_respond_success_std(
+        response_handle,
+        &(struct std_value){
+            .type = kStdList,
+            .size = 2,
+            .list = (struct std_value[2]){ STDINT32(wv->browser_id), STDINT64(wv->texture_id) },
+        }
+    );
+}
+
+/// For `close`, `reload`, `goBack` and `goForward`, which take the browser id as
+/// a bare integer.
+static struct webview *
+webview_from_bare_id(struct std_value *args, FlutterPlatformMessageResponseHandle *response_handle, int *response_out) {
+    struct webview *wv;
+
+    if (args == NULL || !STDVALUE_IS_INT(*args)) {
+        *response_out = platch_respond_illegal_arg_std(response_handle, "Expected the browser id to be an integer.");
+        return NULL;
+    }
+
+    wv = webview_find((int) STDVALUE_AS_INT(*args));
+    if (wv == NULL || wv->closing) {
+        *response_out = platch_respond_error_std(response_handle, "no-such-webview", "There is no webview with that browser id.", &STDNULL);
+        return NULL;
+    }
+
+    return wv;
+}
+
+/// For everything else: the browser id is the first element of the argument list.
+static struct webview *webview_from_list(struct std_value *args, FlutterPlatformMessageResponseHandle *response_handle, int *response_out) {
+    struct webview *wv;
+    int64_t browser_id;
+
+    if (!arg_int_at(args, 0, &browser_id)) {
+        *response_out = platch_respond_illegal_arg_std(response_handle, "Expected a list with the browser id as its first element.");
+        return NULL;
+    }
+
+    wv = webview_find((int) browser_id);
+    if (wv == NULL || wv->closing) {
+        *response_out = platch_respond_error_std(response_handle, "no-such-webview", "There is no webview with that browser id.", &STDNULL);
+        return NULL;
+    }
+
+    return wv;
+}
+
+static int on_close(struct std_value *args, FlutterPlatformMessageResponseHandle *response_handle) {
+    struct webview *wv;
+    int response = 0;
+
+    wv = webview_from_bare_id(args, response_handle, &response);
+    if (wv == NULL) {
+        return response;
+    }
+
+    wv->closing = true;
+    webview_release_textures(wv);
+
+    if (wv->browser != NULL) {
+        // `wv` is freed in on_browser_closed.
+        wvcef_browser_close(wv->browser);
+    } else {
+        webview_free(wv);
+    }
+
+    return platch_respond_success_std(response_handle, &STDNULL);
+}
+
+static int on_load_url(struct std_value *args, FlutterPlatformMessageResponseHandle *response_handle) {
+    struct webview *wv;
+    const char *url;
+    int response = 0;
+
+    wv = webview_from_list(args, response_handle, &response);
+    if (wv == NULL) {
+        return response;
+    }
+
+    url = arg_string_at(args, 1);
+    if (url == NULL) {
+        return platch_respond_illegal_arg_std(response_handle, "Expected the url to be a string.");
+    }
+
+    wvcef_browser_load_url(wv->browser, url);
+
+    return platch_respond_success_std(response_handle, &STDNULL);
+}
+
+static int on_set_size(struct std_value *args, FlutterPlatformMessageResponseHandle *response_handle) {
+    struct webview *wv;
+    double dpi = 1.0, width = 0.0, height = 0.0;
+    int response = 0;
+
+    wv = webview_from_list(args, response_handle, &response);
+    if (wv == NULL) {
+        return response;
+    }
+
+    if (!arg_num_at(args, 1, &dpi) || !arg_num_at(args, 2, &width) || !arg_num_at(args, 3, &height)) {
+        return platch_respond_illegal_arg_std(response_handle, "Expected [browserId, dpi, width, height].");
+    }
+
+    if (dpi <= 0.0) {
+        dpi = 1.0;
+    }
+
+    wv->pixel_ratio = dpi;
+    wv->logical_width = (int) (width > 1.0 ? width : 1.0);
+    wv->logical_height = (int) (height > 1.0 ? height : 1.0);
+
+    TRACE("setSize: browser %d, %dx%d logical, dpi %.2f\n", wv->browser_id, wv->logical_width, wv->logical_height, wv->pixel_ratio);
+
+    wvcef_browser_resize(wv->browser, wv->logical_width, wv->logical_height, wv->pixel_ratio);
+
+    return platch_respond_success_std(response_handle, &STDNULL);
+}
+
+/// cursorMove, cursorDragging, cursorClickDown and cursorClickUp all take
+/// [browserId, x, y].
+static int on_cursor_event(const char *method, struct std_value *args, FlutterPlatformMessageResponseHandle *response_handle) {
+    struct webview *wv;
+    int64_t x = 0, y = 0;
+    int response = 0;
+
+    wv = webview_from_list(args, response_handle, &response);
+    if (wv == NULL) {
+        return response;
+    }
+
+    if (!arg_int_at(args, 1, &x) || !arg_int_at(args, 2, &y)) {
+        return platch_respond_illegal_arg_std(response_handle, "Expected [browserId, x, y].");
+    }
+
+    if (streq(method, "cursorMove")) {
+        wvcef_browser_send_mouse_move(wv->browser, (int) x, (int) y, false);
+    } else if (streq(method, "cursorDragging")) {
+        wvcef_browser_send_mouse_move(wv->browser, (int) x, (int) y, true);
+    } else if (streq(method, "cursorClickDown")) {
+        wvcef_browser_send_mouse_click(wv->browser, (int) x, (int) y, false);
+    } else {
+        wvcef_browser_send_mouse_click(wv->browser, (int) x, (int) y, true);
+    }
+
+    return platch_respond_success_std(response_handle, &STDNULL);
+}
+
+static int on_set_scroll_delta(struct std_value *args, FlutterPlatformMessageResponseHandle *response_handle) {
+    struct webview *wv;
+    int64_t x = 0, y = 0, delta_x = 0, delta_y = 0;
+    int response = 0;
+
+    wv = webview_from_list(args, response_handle, &response);
+    if (wv == NULL) {
+        return response;
+    }
+
+    if (!arg_int_at(args, 1, &x) || !arg_int_at(args, 2, &y) || !arg_int_at(args, 3, &delta_x) || !arg_int_at(args, 4, &delta_y)) {
+        return platch_respond_illegal_arg_std(response_handle, "Expected [browserId, x, y, deltaX, deltaY].");
+    }
+
+    wvcef_browser_send_mouse_wheel(wv->browser, (int) x, (int) y, (int) delta_x, (int) delta_y);
+
+    return platch_respond_success_std(response_handle, &STDNULL);
+}
+
+static int on_set_client_focus(struct std_value *args, FlutterPlatformMessageResponseHandle *response_handle) {
+    struct webview *wv;
+    bool focused = true;
+    int response = 0;
+
+    wv = webview_from_list(args, response_handle, &response);
+    if (wv == NULL) {
+        return response;
+    }
+
+    arg_bool_at(args, 1, &focused);
+
+    wvcef_browser_set_focus(wv->browser, focused);
+
+    return platch_respond_success_std(response_handle, &STDNULL);
+}
+
+/// imeSetComposition and imeCommitText both take [browserId, text]. This is how
+/// the dart side delivers typed text -- see the README about what it takes for
+/// the page to ask for it by itself.
+static int on_ime_text(const char *method, struct std_value *args, FlutterPlatformMessageResponseHandle *response_handle) {
+    struct webview *wv;
+    const char *text;
+    int response = 0;
+
+    wv = webview_from_list(args, response_handle, &response);
+    if (wv == NULL) {
+        return response;
+    }
+
+    text = arg_string_at(args, 1);
+    if (text == NULL) {
+        return platch_respond_illegal_arg_std(response_handle, "Expected [browserId, text].");
+    }
+
+    if (streq(method, "imeCommitText")) {
+        wvcef_browser_ime_commit_text(wv->browser, text);
+    } else {
+        wvcef_browser_ime_set_composition(wv->browser, text);
+    }
+
+    return platch_respond_success_std(response_handle, &STDNULL);
+}
+
+static int on_execute_javascript(struct std_value *args, FlutterPlatformMessageResponseHandle *response_handle) {
+    struct webview *wv;
+    const char *code;
+    int response = 0;
+
+    wv = webview_from_list(args, response_handle, &response);
+    if (wv == NULL) {
+        return response;
+    }
+
+    code = arg_string_at(args, 1);
+    if (code == NULL) {
+        return platch_respond_illegal_arg_std(response_handle, "Expected the javascript code to be a string.");
+    }
+
+    wvcef_browser_execute_javascript(wv->browser, code);
+
+    return platch_respond_success_std(response_handle, &STDNULL);
+}
+
+static int on_navigation(const char *method, struct std_value *args, FlutterPlatformMessageResponseHandle *response_handle) {
+    struct webview *wv;
+    int response = 0;
+
+    wv = webview_from_bare_id(args, response_handle, &response);
+    if (wv == NULL) {
+        return response;
+    }
+
+    if (streq(method, "reload")) {
+        wvcef_browser_reload(wv->browser, false);
+    } else if (streq(method, "goBack")) {
+        wvcef_browser_go_back(wv->browser);
+    } else {
+        wvcef_browser_go_forward(wv->browser);
+    }
+
+    return platch_respond_success_std(response_handle, &STDNULL);
+}
+
+/**
+ * @brief `quit` only releases the browsers.
+ *
+ * CEF cannot be initialized twice in a process, so actually calling CefShutdown
+ * here would make every later webview fail. flutter-pi tears CEF down in the
+ * plugin's deinit anyway, which is the only point where nothing can come back.
+ */
+static int on_quit(FlutterPlatformMessageResponseHandle *response_handle) {
+    for (struct webview *wv = plugin.webviews, *next = NULL; wv != NULL; wv = next) {
+        next = wv->next;
+
+        wv->closing = true;
+        webview_release_textures(wv);
+
+        if (wv->browser != NULL) {
+            wvcef_browser_close(wv->browser);
+        } else {
+            webview_free(wv);
+        }
+    }
+
+    return platch_respond_success_std(response_handle, &STDNULL);
+}
+
+static int on_receive(char *channel, struct platch_obj *object, FlutterPlatformMessageResponseHandle *response_handle) {
+    struct std_value *args;
+    const char *method;
+
+    (void) channel;
+
+    method = object->method;
+    args = &object->std_arg;
+
+    if (streq(method, "init")) {
+        return on_init(args, response_handle);
+    } else if (streq(method, "create")) {
+        return on_create(args, response_handle);
+    } else if (streq(method, "close")) {
+        return on_close(args, response_handle);
+    } else if (streq(method, "loadUrl")) {
+        return on_load_url(args, response_handle);
+    } else if (streq(method, "setSize")) {
+        return on_set_size(args, response_handle);
+    } else if (streq(method, "setScrollDelta")) {
+        return on_set_scroll_delta(args, response_handle);
+    } else if (streq(method, "setClientFocus")) {
+        return on_set_client_focus(args, response_handle);
+    } else if (streq(method, "executeJavaScript")) {
+        return on_execute_javascript(args, response_handle);
+    } else if (streq(method, "imeCommitText") || streq(method, "imeSetComposition")) {
+        return on_ime_text(method, args, response_handle);
+    } else if (streq(method, "quit")) {
+        return on_quit(response_handle);
+    } else if (streq(method, "cursorMove") || streq(method, "cursorDragging") || streq(method, "cursorClickDown") ||
+               streq(method, "cursorClickUp")) {
+        return on_cursor_event(method, args, response_handle);
+    } else if (streq(method, "reload") || streq(method, "goBack") || streq(method, "goForward")) {
+        return on_navigation(method, args, response_handle);
+    }
+
+    // Not implemented, on purpose:
+    //   evaluateJavascript, setJavaScriptChannels, sendJavaScriptChannelCallBack
+    //     -- need a CefRenderProcessHandler in the subprocess helper plus IPC to
+    //        get values back out of V8.
+    //   openDevTools -- needs a real window to put the inspector in.
+    //   setCookie, deleteCookie, visitAllCookies, visitUrlCookies
+    //     -- straightforward to add on top of CefCookieManager, just not done.
+    return platch_respond_not_implemented(response_handle);
+}
+
+// ---------------------------------------------------------------------------
+// plugin lifecycle
+// ---------------------------------------------------------------------------
+
+enum plugin_init_result webview_cef_init(struct flutterpi *flutterpi, void **userdata_out) {
+    struct gl_renderer *renderer;
+    EGLDisplay display;
+    EGLContext context;
+    int ok;
+
+    if (!flutterpi_has_gl_renderer(flutterpi)) {
+        LOG_ERROR("The webview plugin needs EGL/OpenGL ES rendering, which is not available. Webviews will not work.\n");
+        return PLUGIN_INIT_RESULT_NOT_APPLICABLE;
+    }
+
+    renderer = flutterpi_get_gl_renderer(flutterpi);
+
+    display = gl_renderer_get_egl_display(renderer);
+    if (display == EGL_NO_DISPLAY) {
+        LOG_ERROR("The GL renderer has no EGL display.\n");
+        return PLUGIN_INIT_RESULT_NOT_APPLICABLE;
+    }
+
+    // Shares the flutter root context, so the textures we fill here can be
+    // sampled by the flutter rasterizer.
+    context = gl_renderer_create_context(renderer);
+    if (context == EGL_NO_CONTEXT) {
+        LOG_ERROR("Could not create an EGL context for the webview plugin. eglCreateContext: 0x%04X\n", eglGetError());
+        return PLUGIN_INIT_RESULT_ERROR;
+    }
+
+    memset(&plugin, 0, sizeof plugin);
+
+    plugin.flutterpi = flutterpi;
+    plugin.egl_display = display;
+    plugin.egl_context = context;
+    // Any value means on; a number picks the level. Spelling it this way keeps
+    // FLUTTERPI_CEF_TRACE=1 and a bare FLUTTERPI_CEF_TRACE= both meaning "trace".
+    plugin.trace_level = getenv("FLUTTERPI_CEF_TRACE") == NULL ? 0 : (int) resolve_env_long("FLUTTERPI_CEF_TRACE", 1);
+
+    // The BGRA path uploads with GL_BGRA_EXT as the internal format, but the
+    // frame is handed to the engine as GL_RGBA8_OES, which is what every other
+    // texture source in flutter-pi reports. If a driver's Skia backend refuses
+    // that combination the webview goes silently blank -- no GL error, nothing
+    // in the log -- so keep a way to fall back to the CPU conversion in place
+    // rather than having to rebuild to find out.
+    plugin.supports_bgra = gl_renderer_supports_gl_extension(renderer, "GL_EXT_texture_format_BGRA8888") &&
+                           getenv("FLUTTERPI_CEF_FORCE_RGBA") == NULL;
+
+    TRACE("plugin up. BGRA textures: %s\n", plugin.supports_bgra ? "yes" : "no, converting on the CPU");
+
+    if (!plugin.supports_bgra) {
+        LOG_ERROR("GL_EXT_texture_format_BGRA8888 is missing; webview frames will be converted on the CPU, which is slow.\n");
+    }
+
+    pthread_mutex_init(&plugin.gl_mutex, NULL);
+
+    ok = plugin_registry_set_receiver_locked(WEBVIEW_CEF_CHANNEL, kStandardMethodCall, on_receive);
+    if (ok != 0) {
+        LOG_ERROR("Could not set the webview platform channel receiver: %s\n", strerror(ok));
+        pthread_mutex_destroy(&plugin.gl_mutex);
+        eglDestroyContext(display, context);
+        return PLUGIN_INIT_RESULT_ERROR;
+    }
+
+    // CEF itself is only started on the first `init`/`create` call, so an app
+    // that never opens a webview doesn't pay for Chromium's ~150MB of RAM.
+    //
+    // Plugins are initialized before the flutter engine is created though, so
+    // starting CEF here means its helper processes are forked out of a process
+    // that isn't heavily threaded yet, and Chromium's signal handlers are
+    // installed before the engine's. If lazy initialization ever turns out to be
+    // flaky, set FLUTTERPI_CEF_EAGER_INIT=1.
+    if (getenv("FLUTTERPI_CEF_EAGER_INIT") != NULL) {
+        ok = ensure_cef_initialized(NULL);
+        if (ok != 0) {
+            LOG_ERROR("Eager CEF initialization failed: %s. Webviews will not work.\n", strerror(ok));
+        }
+    }
+
+    *userdata_out = &plugin;
+    return PLUGIN_INIT_RESULT_INITIALIZED;
+}
+
+void webview_cef_deinit(struct flutterpi *flutterpi, void *userdata) {
+    (void) flutterpi;
+    (void) userdata;
+
+    plugin_registry_remove_receiver_locked(WEBVIEW_CEF_CHANNEL);
+
+    // Close every browser and let CEF finish the teardown. Without this,
+    // CefShutdown() aborts.
+    for (struct webview *wv = plugin.webviews; wv != NULL; wv = wv->next) {
+        wv->closing = true;
+        webview_release_textures(wv);
+
+        if (wv->browser != NULL) {
+            wvcef_browser_close(wv->browser);
+        }
+    }
+
+    if (wvcef_is_initialized()) {
+        // CEF closes browsers on its own thread, so this only has to wait.
+        // 200 * 10ms = 2s worth of patience.
+        for (int i = 0; i < 200 && wvcef_n_live_browsers() > 0; i++) {
+            nanosleep(&(struct timespec){ .tv_sec = 0, .tv_nsec = 10 * 1000 * 1000 }, NULL);
+        }
+
+        if (wvcef_n_live_browsers() > 0) {
+            LOG_ERROR("%d webview(s) did not close in time; skipping CEF shutdown.\n", wvcef_n_live_browsers());
+        }
+    }
+
+    // Everything is torn down here rather than in on_browser_closed_on_platform,
+    // because that runs as a platform task and the event loop has already stopped
+    // by the time plugins are deinitialized -- the tasks CEF's thread just posted
+    // will never be dispatched. Which also means nothing else is going to touch
+    // these webviews, so freeing them here is safe; the undispatched tasks hold
+    // pointers into them, but the process is on its way out.
+    //
+    // Before wvcef_shutdown(), so no handle outlives the CEF runtime.
+    while (plugin.webviews != NULL) {
+        struct webview *wv = plugin.webviews;
+
+        plugin.webviews = wv->next;
+
+        if (wv->browser != NULL) {
+            wvcef_browser_destroy(wv->browser);
+        }
+
+        free(wv->swizzle_buffer);
+        free(wv);
+    }
+
+    if (wvcef_is_initialized() && wvcef_n_live_browsers() == 0) {
+        wvcef_shutdown();
+    }
+
+    if (plugin.egl_context != EGL_NO_CONTEXT) {
+        eglDestroyContext(plugin.egl_display, plugin.egl_context);
+        plugin.egl_context = EGL_NO_CONTEXT;
+    }
+
+    pthread_mutex_destroy(&plugin.gl_mutex);
+}
+
+FLUTTERPI_PLUGIN("webview_cef", webview_cef_plugin, webview_cef_init, webview_cef_deinit)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -21,3 +21,10 @@ target_link_libraries(
 )
 
 add_test(flutterpi_test flutterpi_test)
+
+if (BUILD_WEBVIEW_CEF_PLUGIN)
+    # flutterpi_module carries C++ objects (the CEF bridge) then, and both test
+    # binaries are C, so CMake would pick the C driver to link them and leave out
+    # the C++ runtime.
+    set_target_properties(platformchannel_test flutterpi_test PROPERTIES LINKER_LANGUAGE CXX)
+endif()


### PR DESCRIPTION
Implements the platform side of the webview_cef pub package, so a flutter app can embed web pages on flutter-pi with the same dart code it uses on desktop. Off by default, enable with -DBUILD_WEBVIEW_CEF_PLUGIN=ON.

flutter-pi has no platform views and owns the DRM master, so a browser cannot be given a window. CEF renders the page off-screen instead and hands over a BGRA buffer, which the plugin uploads into a GL texture on a context sharing flutter's root context and publishes through the texture registry. The dart side shows that with a plain Texture widget and forwards pointer input over the channel.

CEF gets its own thread for the browser process message loop (multi_threaded_message_loop). The external message pump is the more obvious choice -- it makes the platform thread CEF's UI thread, so callbacks need no locks at all -- but a Chromium task on the UI thread will sometimes block waiting for more UI thread work, which only a real message loop can nest and deliver. An external pump deadlocks there, with the page still looking alive.

Chromium is pointed at the GPU through a render node, which needs no DRM master and so does not collide with flutter-pi holding the card. Without that it silently falls back to SwiftShader and rasterises WebGL on the CPU.

The CEF facing code lives behind a plain-C bridge because flutter-pi's headers cannot be included from C++ -- platformchannel.h and friends use compound literals. Chromium's subprocesses get their own executable so a renderer never re-enters flutter-pi's main().

Requires CEF 126 or newer, developed against 132.3.2.

Issues #491 #405 